### PR TITLE
feat: implement handling action in detection rules

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,6 @@
 [build]
-# specifying the two targets here seems necessary to enable
-# VSCode having code analysis for both the targets in workspace
-# members (needed for kunai-common)
-target = ["x86_64-unknown-linux-gnu", "bpfel-unknown-none"]
+# make final binary statically linked against libc
+rustflags = ["-Ctarget-feature=+crt-static"]
 
 [alias]
 # replace with the target triple you are developing on must be the same as
@@ -11,8 +9,3 @@ xtask = "run -q --target=x86_64-unknown-linux-gnu --package xtask --release --"
 xrun = "xtask run"
 xbuild = "xtask build"
 xrelease = "xtask release"
-
-[profile.release]
-lto = true
-codegen-units = 1
-strip = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
- "gimli",
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -31,10 +31,11 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
+ "log",
  "memchr",
 ]
 
@@ -60,6 +61,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -109,9 +120,66 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
+name = "array-bytes"
+version = "6.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5dde061bd34119e902bbb2d9b90c5692635cf59fb91d582c2b68043f1b8293"
+
+[[package]]
+name = "ascii_tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "assert_matches"
@@ -133,7 +201,7 @@ checksum = "90eea657cc8028447cbda5068f4e10c4fadba0131624f4f7dd1a9c46ffc8d81f"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.4.1",
+ "bitflags",
  "bytes",
  "lazy_static",
  "libc",
@@ -179,7 +247,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -190,7 +258,7 @@ checksum = "2c02024a307161cf3d1f052161958fd13b1a33e3e038083e58082c0700fdab85"
 dependencies = [
  "bytes",
  "core-error",
- "hashbrown",
+ "hashbrown 0.14.3",
  "log",
  "object 0.32.2",
  "thiserror",
@@ -212,12 +280,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c69fae65a523209d34240b60abe0c42d33d1045d445c0839d8a4894a736e2d"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -228,23 +329,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.77",
  "which",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bitmask"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da9b3d9f6f585199287a473f4f8dfab6566cf827d15c00c219f53c645687ead"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -256,10 +369,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.12.0"
+name = "bstr"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -269,9 +393,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
@@ -338,7 +462,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -347,10 +471,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -358,6 +482,12 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "codespan-reporting"
@@ -376,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-error"
 version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,12 +542,134 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
+name = "cranelift-bforest"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "0b6b33d7e757a887989eb18b35712b2a67d96171ec3149d1bfb657b29b7b367c"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9acf15cb22be42d07c3b57d7856329cb228b7315d385346149df2566ad5e4aa"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.28.1",
+ "hashbrown 0.14.3",
+ "log",
+ "regalloc2",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e934d301392b73b3f8b0540391fb82465a0f179a3cee7c726482ac4727efcc97"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb2a2566b3d54b854dfb288b3b187f6d3d17d6f762c92898207eba302931da"
+
+[[package]]
+name = "cranelift-control"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0100f33b704cdacd01ad66ff41f8c5030d57cbff078e2a4e49ab1822591299fa"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f74b84f16af2e982b0c0c72233503d9d55cbfe3865dbe807ca28dc6642a28b5"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf306d3dde705fb94bd48082f01d38c4ededc74293a4c007805f610bf08bc6e"
+
+[[package]]
+name = "cranelift-native"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea0ebdef7aff4a79bcbc8b6495f31315f16b3bf311152f472eaa8d679352581"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d549108a1942065cdbac3bb96c2952afa0e1b9a3beff4b08c4308ac72257576d"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools 0.12.1",
+ "log",
+ "smallvec",
+ "wasmparser 0.209.1",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -463,6 +727,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,12 +814,25 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -494,10 +846,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "env_logger"
@@ -520,30 +947,41 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "fallible-iterator"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "firo"
@@ -566,6 +1004,48 @@ dependencies = [
  "crc32fast",
  "miniz_oxide 0.6.2",
 ]
+
+[[package]]
+name = "fmmap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099ab52d5329340a3014f60ca91bc892181ae32e752360d07be9295924dcb0b"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "enum_dispatch",
+ "fs4",
+ "memmapix",
+ "parse-display",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-walk"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374863c473230fd79ba996708da75f971f3a611470d2dced5161430201edac02"
+
+[[package]]
+name = "fs4"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -680,7 +1160,7 @@ checksum = "25a9d7de78d8c76dd6ffb1fe216c01a2b6162506447848e96e9cdae251ad2dd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -691,6 +1171,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -706,6 +1187,28 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator 0.2.0",
+ "indexmap 1.9.3",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "indexmap 2.4.0",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
@@ -717,6 +1220,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +1277,16 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -743,6 +1306,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "huby"
@@ -785,14 +1366,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.0.0"
+name = "id-arena"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
+ "serde",
 ]
+
+[[package]]
+name = "intaglio"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa3eb1c7e05b0f9ddc99a1e9f186a434fa0bfd0087d6369acf5f2814731ab610"
 
 [[package]]
 name = "ip_network"
@@ -809,6 +1436,24 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -844,6 +1489,7 @@ dependencies = [
  "clap",
  "env_logger",
  "firo",
+ "fs-walk",
  "futures",
  "gene",
  "gene_derive",
@@ -852,7 +1498,6 @@ dependencies = [
  "ip_network",
  "kunai-common",
  "kunai-macros",
- "lazy_static",
  "libc",
  "log",
  "lru-st",
@@ -863,10 +1508,12 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
  "uuid",
+ "yara-x",
 ]
 
 [[package]]
@@ -893,7 +1540,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -901,6 +1548,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -909,10 +1559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libc"
-version = "0.2.155"
+name = "leb128"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -925,6 +1581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,10 +1596,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.10"
+name = "linkme"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "3c943daedff228392b791b33bba32e75737756e80a613e32e246c6ce9cbab20a"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -946,6 +1628,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "logos"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1ceb190eb9bdeecdd8f1ad6a71d6d632a50905948771718741b5461fb01e13"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90be66cb7bd40cb5cc2e9cfaf2d1133b04a3d93b72344267715010a466e0915a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.4",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45154231e8e96586b39494029e58f12f8ffcb5ecf80333a603a13aa205ea8cbd"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -958,19 +1673,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "md-5"
-version = "0.10.5"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "md2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4f0f3ed25ff4f8d8d102288d92f900efc202661c884cf67dfe4f0d07c43d1f"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memfd"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
+name = "memmapix"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f517ab414225d5f1755bd284d9545bd08a72a3958b3c6384d72e95de9cc1a1d3"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memx"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93022fcc0eab2dc9dd134e362592e06f0b3c0aa549ae91d8b3e539e56c2a0687"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1019,12 +1789,77 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
+name = "num-bigint"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1053,7 +1888,19 @@ version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.14.3",
+ "indexmap 2.4.0",
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1061,6 +1908,56 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
+dependencies = [
+ "once_cell",
+ "parse-display-derive",
+ "regex",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68517892c8daf78da08c0db777fcc17e07f2f63ef70041718f8a7630ad84f341"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax 0.7.5",
+ "structmeta",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "paste"
@@ -1073,6 +1970,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "pest"
@@ -1105,7 +2011,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1132,13 +2038,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "postcard"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1166,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1179,7 +2142,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags",
  "chrono",
  "flate2",
  "hex",
@@ -1194,9 +2157,69 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags",
  "chrono",
  "hex",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bcc343da15609eaecd65f8aa76df8dc4209d325131d8219358c0aaaebab0bf6"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d0cde5642ea4df842b13eb9f59ea6fafa26dcb43e3e1ee49120e9757556189"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b0e9b447d099ae2c4993c0cbb03c7a9d6c937b17f2d56cfc0b1550e6fcfdb76"
+dependencies = [
+ "anyhow",
+ "indexmap 2.4.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0766e3675a627c327e4b3964582594b0e8741305d628a98a5de75a1d15f99b9"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1215,12 +2238,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
+name = "radium"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "bitflags 1.3.2",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash 1.1.0",
+ "slice-group-by",
+ "smallvec",
 ]
 
 [[package]]
@@ -1232,25 +2294,79 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rowan"
+version = "0.15.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.3",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1265,16 +2381,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustix"
-version = "0.38.21"
+name = "rustc-hash"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "bitflags 2.4.1",
+ "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+dependencies = [
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1301,10 +2432,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1323,7 +2483,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1332,16 +2492,28 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap 2.4.0",
  "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.3"
+name = "serde_repr"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -1352,7 +2524,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap",
+ "indexmap 2.4.0",
  "itoa",
  "ryu",
  "serde",
@@ -1361,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1372,15 +2544,15 @@ dependencies = [
 
 [[package]]
 name = "sha1_smol"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1403,12 +2575,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1420,6 +2617,34 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -1434,6 +2659,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1456,16 +2716,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.8.1"
+name = "synstructure"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "syscalls"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d0e35dc7d73976a53c7e6d7d177ef804a0c0ee774ec77bcc520c2216fd7cbe"
+dependencies = [
+ "serde",
+ "serde_repr",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1476,6 +2769,12 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -1494,8 +2793,55 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tlsh-fixed"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f762ca8308eda1e38512dc88a99f021e5214699ba133de157f588c8bfd0745c7"
 
 [[package]]
 name = "tokio"
@@ -1522,7 +2868,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1539,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -1552,7 +2898,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1588,10 +2934,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
+name = "unicode-segmentation"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1621,6 +2979,44 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "walrus"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
+dependencies = [
+ "anyhow",
+ "gimli 0.26.2",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "wasi"
@@ -1683,6 +3079,232 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.212.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.3",
+ "indexmap 2.4.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.212.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.3",
+ "indexmap 2.4.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
+dependencies = [
+ "anyhow",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wasmtime"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d8b5e7a4d54917c5ebe555b9667337e5f93383f49bddaaeec2eba68093b45"
+dependencies = [
+ "anyhow",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "indexmap 2.4.0",
+ "libc",
+ "libm",
+ "log",
+ "mach2",
+ "memfd",
+ "memoffset",
+ "object 0.36.2",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "wasmparser 0.209.1",
+ "wasmtime-asm-macros",
+ "wasmtime-component-macro",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d697d99c341d4a9ffb72f3af7a02124d233eeb59aee010f36d88e97cca553d5e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29b462b068e73b5b27fae092a27f47e5937cabf6b26be2779c978698a52feca"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3975deafea000457ba84355c7c0fce0372937204f77026510b7b454f28a3a65"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli 0.28.1",
+ "log",
+ "object 0.36.2",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.209.1",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
+dependencies = [
+ "anyhow",
+ "cranelift-entity",
+ "gimli 0.28.1",
+ "indexmap 2.4.0",
+ "log",
+ "object 0.36.2",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
+ "wasmprinter",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afe2f0499542f9a4bcfa1b55bfdda803b6ade4e7c93c6b99e0f39dba44b0a91"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7de1f2bec5bbb35d532e61c85c049dc84ae671df60492f90b954ecf21169e7"
+
+[[package]]
+name = "wasmtime-types"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5a9bc4f44ceeb168e9e8e3be4e0b4beb9095b468479663a9e24c667e36826f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "indexmap 2.4.0",
+ "wit-parser",
+]
+
+[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +3360,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -1873,6 +3504,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.4.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xtask"
 version = "0.2.4"
 dependencies = [
@@ -1883,11 +3558,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yara-x"
+version = "0.7.0"
+source = "git+https://github.com/VirusTotal/yara-x.git#c07380bbf5c862779ff30c29f10e816c9629b29d"
+dependencies = [
+ "aho-corasick",
+ "annotate-snippets",
+ "anyhow",
+ "array-bytes",
+ "ascii_tree",
+ "base64",
+ "bincode",
+ "bitmask",
+ "bitvec",
+ "bstr",
+ "const-oid",
+ "crc32fast",
+ "der-parser",
+ "digest",
+ "dsa",
+ "ecdsa",
+ "fmmap",
+ "globwalk",
+ "indexmap 2.4.0",
+ "intaglio",
+ "itertools 0.13.0",
+ "lazy_static",
+ "linkme",
+ "md-5",
+ "md2",
+ "memchr",
+ "memx",
+ "nom",
+ "num-derive",
+ "num-traits",
+ "p256",
+ "p384",
+ "protobuf",
+ "protobuf-codegen",
+ "protobuf-parse",
+ "regex-automata",
+ "regex-syntax 0.8.4",
+ "roxmltree",
+ "rsa",
+ "rustc-hash 2.0.0",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "syscalls",
+ "thiserror",
+ "tlsh-fixed",
+ "uuid",
+ "walrus",
+ "wasmtime",
+ "x509-parser",
+ "yansi",
+ "yara-x-macros",
+ "yara-x-parser",
+ "yara-x-proto",
+]
+
+[[package]]
+name = "yara-x-macros"
+version = "0.7.0"
+source = "git+https://github.com/VirusTotal/yara-x.git#c07380bbf5c862779ff30c29f10e816c9629b29d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "yara-x-parser"
+version = "0.7.0"
+source = "git+https://github.com/VirusTotal/yara-x.git#c07380bbf5c862779ff30c29f10e816c9629b29d"
+dependencies = [
+ "ascii_tree",
+ "bitmask",
+ "bstr",
+ "indexmap 2.4.0",
+ "itertools 0.13.0",
+ "logos",
+ "num-traits",
+ "rowan",
+ "rustc-hash 2.0.0",
+ "serde",
+ "yansi",
+]
+
+[[package]]
+name = "yara-x-proto"
+version = "0.7.0"
+source = "git+https://github.com/VirusTotal/yara-x.git#c07380bbf5c862779ff30c29f10e816c9629b29d"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+ "protobuf-parse",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -1899,5 +3683,11 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,12 @@ authors = ["Quentin JEROME <qjerome@rawsec.lu>"]
 license = "GPL-3.0"
 license-file = "LICENSE"
 repository = "https://github.com/kunai-project/kunai"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+
+[profile.dev-opt]
+inherits = "dev"
+opt-level = 3

--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -113,9 +113,14 @@ pub enum Type {
     #[str("file_unlink")]
     FileUnlink,
 
-    // Materialize end of possible events
-    #[str("end_event")]
-    EndEvents = 1000,
+    // specific userland events
+    // those should never be used in eBPF
+    #[str("file_scan")]
+    FileScan = 500,
+
+    // Materialize the end of configurable events
+    #[str("end_configurable")]
+    EndConfigurable = 1000,
 
     // specific events
     #[str("correlation")]
@@ -140,10 +145,10 @@ impl Default for Type {
 
 impl Type {
     pub fn is_configurable(&self) -> bool {
-        *self > Self::Unknown && *self < Self::EndEvents
+        *self > Self::Unknown && *self < Self::EndConfigurable
     }
 
-    pub fn id(&self) -> u32 {
+    pub const fn id(&self) -> u32 {
         *self as u32
     }
 }

--- a/kunai-common/src/bpf_events/events.rs
+++ b/kunai-common/src/bpf_events/events.rs
@@ -79,9 +79,15 @@ const fn max_bpf_event_size() -> usize {
             }
             Type::FileRename => FileRenameEvent::size_of(),
             Type::FileUnlink => UnlinkEvent::size_of(),
-            Type::Unknown | Type::EndEvents | Type::Correlation | Type::CacheHash | Type::Max => 0,
             Type::Error => ErrorEvent::size_of(),
             Type::SyscoreResume => SysCoreResumeEvent::size_of(),
+            // these are event types only used in user land
+            Type::Unknown
+            | Type::EndConfigurable
+            | Type::Correlation
+            | Type::CacheHash
+            | Type::Max
+            | Type::FileScan => 0,
             // never handle _ pattern otherwise this function loses all interest
         };
         if size > max {

--- a/kunai-common/src/time.rs
+++ b/kunai-common/src/time.rs
@@ -7,6 +7,12 @@ pub struct Time {
     pub nsec: i64,
 }
 
+impl Time {
+    pub fn new(sec: i64, nsec: i64) -> Self {
+        Self { sec, nsec }
+    }
+}
+
 not_bpf_target_code! {
     use std::time::{SystemTime, UNIX_EPOCH};
     use core::time::Duration;

--- a/kunai-ebpf/.cargo/config.toml
+++ b/kunai-ebpf/.cargo/config.toml
@@ -4,3 +4,28 @@ target = ["bpfel-unknown-none"]
 
 [unstable]
 build-std = ["core"]
+
+# moved profile out of Cargo.toml
+# so that profiles also applies to
+# dependencies
+
+[profile.dev]
+opt-level = 3
+# enable DI
+debug = 2
+debug-assertions = false
+overflow-checks = false
+lto = true
+panic = "abort"
+incremental = false
+codegen-units = 1
+rpath = false
+
+[profile.release]
+opt-level = 3
+# enable DI
+debug = 2
+debug-assertions = false
+lto = true
+panic = "abort"
+codegen-units = 1

--- a/kunai-ebpf/Cargo.toml
+++ b/kunai-ebpf/Cargo.toml
@@ -22,26 +22,5 @@ paste = "1.0"
 name = "kunai-ebpf"
 path = "src/main.rs"
 
-[profile.dev]
-opt-level = 3
-# enable DI
-debug = 2
-debug-assertions = false
-overflow-checks = false
-lto = true
-panic = "abort"
-incremental = false
-codegen-units = 1
-rpath = false
-
-[profile.release]
-opt-level = 3
-# enable DI
-debug = 2
-debug-assertions = false
-lto = true
-panic = "abort"
-codegen-units = 1
-
 [workspace]
 members = []

--- a/kunai/.cargo/config.toml
+++ b/kunai/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = ["x86_64-unknown-linux-gnu"]

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -53,11 +53,31 @@ toml = "0.7.4"
 serde = { version = "1.0.164", features = ["derive"] }
 clap = { version = "4.3.4", features = ["derive"] }
 serde_json = "1.0.108"
-uuid = { version = "1.6.1", features = ["serde", "v5"] }
+uuid = { version = "1.6.1", features = ["serde", "v4", "v5"] }
 object = { version = "0.34.0", features = ["elf"] }
 huby = { version = "0.1", features = ["serde"] }
 firo = { version = "0.1" }
+yara-x = { git = "https://github.com/VirusTotal/yara-x.git", features = [
+    "constant-folding",
+    "exact-atoms",
+    "fast-regexp",
+    "console-module",
+    "dotnet-module",
+    "elf-module",
+    "macho-module",
+    "math-module",
+    "hash-module",
+    "pe-module",
+    "string-module",
+    "time-module",
+    "lnk-module",
+    "test_proto2-module",
+    "test_proto3-module",
+], default-features = false }
+fs-walk = { version = "0.1.0" }
 
+[dev-dependencies]
+tempfile = "3.12.0"
 
 [[bin]]
 name = "kunai"

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -52,7 +52,6 @@ tokio = { version = "1.39", features = [
 toml = "0.7.4"
 serde = { version = "1.0.164", features = ["derive"] }
 clap = { version = "4.3.4", features = ["derive"] }
-lazy_static = "1.4.0"
 serde_json = "1.0.108"
 uuid = { version = "1.6.1", features = ["serde", "v5"] }
 object = { version = "0.34.0", features = ["elf"] }

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -7,18 +7,21 @@ use bytes::BytesMut;
 use clap::builder::styling;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use env_logger::Builder;
+use fs_walk::WalkOptions;
 use gene::rules::MAX_SEVERITY;
 use gene::Engine;
 use kunai::containers::Container;
 use kunai::events::{
     BpfProgLoadData, BpfProgTypeInfo, BpfSocketFilterData, CloneData, ConnectData, DnsQueryData,
-    ExecveData, ExitData, FileRenameData, FilterInfo, InitModuleData, KillData, KunaiEvent,
-    MmapExecData, MprotectData, NetworkInfo, PrctlData, RWData, ScanResult, SendDataData,
-    SocketInfo, TargetTask, UnlinkData, UserEvent,
+    EventInfo, ExecveData, ExitData, FileRenameData, FileScanData, FilterInfo, InitModuleData,
+    KillData, KunaiEvent, MmapExecData, MprotectData, NetworkInfo, PrctlData, RWData, ScanResult,
+    SendDataData, SocketInfo, TargetTask, UnlinkData, UserEvent,
 };
 use kunai::info::{AdditionalInfo, StdEventInfo, TaskKey};
 use kunai::ioc::IoC;
 use kunai::util::uname::Utsname;
+
+use kunai::yara::{Scanner, SourceCode};
 use kunai::{cache, util};
 use kunai_common::bpf_events::{
     self, error, event, mut_event, EncodedEvent, Event, PrctlOption, Signal, Type,
@@ -28,10 +31,11 @@ use kunai_common::config::{BpfConfig, Filter};
 use kunai_common::{inspect_err, kernel};
 
 use kunai_common::version::KernelVersion;
+use kunai_macros::StrEnum;
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
+
 use tokio::sync::mpsc::error::SendError;
-use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
 use std::borrow::Cow;
@@ -43,6 +47,7 @@ use std::net::IpAddr;
 
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
+
 use std::str::FromStr;
 
 use std::sync::Arc;
@@ -62,7 +67,7 @@ use aya::{BpfLoader, Btf, VerifierLogLevel};
 
 use log::{debug, error, info, warn};
 
-use tokio::sync::{mpsc, Barrier, Mutex, RwLock};
+use tokio::sync::{mpsc, Barrier, Mutex};
 use tokio::{task, time};
 
 use kunai::cache::*;
@@ -174,7 +179,22 @@ impl io::Write for Output {
     }
 }
 
-struct EventConsumer {
+/// enum of supported actions
+#[derive(StrEnum)]
+enum Actions {
+    #[str("kill")]
+    Kill,
+    #[str("scan-files")]
+    ScanFiles,
+}
+
+impl std::fmt::Display for Actions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+struct EventConsumer<'s> {
     system_info: SystemInfo,
     engine: gene::Engine,
     iocs: HashSet<String>,
@@ -183,10 +203,12 @@ struct EventConsumer {
     tasks: HashMap<TaskKey, Task>,
     resolved: HashMap<IpAddr, String>,
     output: Output,
-    task: Option<JoinHandle<Result<(), anyhow::Error>>>,
+    file_scanner: Option<Scanner<'s>>,
+    // used to check if we must generate FileScan events
+    scan_events_enabled: bool,
 }
 
-impl EventConsumer {
+impl<'s> EventConsumer<'s> {
     fn prepare_output(config: &Config) -> anyhow::Result<Output> {
         let output = match &config.output.as_str() {
             &"stdout" => String::from("/dev/stdout"),
@@ -244,8 +266,15 @@ impl EventConsumer {
             tasks: HashMap::new(),
             resolved: HashMap::new(),
             output: Self::prepare_output(&config)?,
-            task: None,
+            file_scanner: None,
+            scan_events_enabled: config
+                .events
+                .iter()
+                .any(|e| e.name() == Type::FileScan.as_str() && e.is_enabled()),
         };
+
+        // initializing yara rules
+        ep.init_file_scanner(&config)?;
 
         // loading rules in the engine
         if !config.rules.is_empty() {
@@ -280,27 +309,42 @@ impl EventConsumer {
         Ok(ep)
     }
 
-    /// Listen for events on the receiver
-    pub async fn consume(
-        self,
-        mut receiver: mpsc::Receiver<EncodedEvent>,
-    ) -> anyhow::Result<Arc<RwLock<EventConsumer>>> {
-        let ep = Arc::new(RwLock::new(self));
+    #[inline(always)]
+    fn init_file_scanner(&mut self, config: &Config) -> anyhow::Result<()> {
+        let wo = WalkOptions::new()
+            // we list only files
+            .files()
+            // will list only files
+            // with following extensions
+            .extension("yar")
+            .extension("yara")
+            // don't go recursive
+            .max_depth(0);
 
-        let shared = Arc::clone(&ep);
+        let mut c = yara_x::Compiler::new();
 
-        // we spawn thread only if there is a receiver
-        ep.write().await.task = Some(tokio::spawn(async move {
-            while let Some(mut enc) = receiver.recv().await {
-                // lock error is a symptom of implementation mistake so we panic
-                let mut ep = shared.write().await;
-                ep.handle_event(&mut enc);
+        let mut files_loaded = 0;
+        for p in config.yara.iter() {
+            debug!("looking for yara rules in: {}", p);
+            let w = wo.clone().walk(p);
+            for r in w {
+                let rule_file = r?;
+                info!(
+                    "loading yara rule(s) from file: {}",
+                    rule_file.to_string_lossy()
+                );
+                let src = SourceCode::from_rule_file(rule_file)?;
+                c.add_source(src.to_native())?;
+                files_loaded += 1;
             }
+        }
 
-            Ok::<(), anyhow::Error>(())
-        }));
+        // we don't actually initialize an empty scanner
+        if files_loaded > 0 {
+            self.file_scanner = Some(Scanner::with_rules(c.build()));
+        }
 
-        Ok(ep)
+        Ok(())
     }
 
     fn load_iocs<P: AsRef<Path>>(&mut self, p: P) -> io::Result<()> {
@@ -522,25 +566,25 @@ impl EventConsumer {
     }
 
     #[inline]
-    fn get_hashes_with_ns(
-        &mut self,
-        ns: Option<Namespace>,
-        p: &kunai_common::path::Path,
-    ) -> Hashes {
+    fn get_hashes_with_ns(&mut self, ns: Option<Namespace>, p: &cache::Path) -> Hashes {
         if let Some(ns) = ns {
             match self.cache.get_or_cache_in_ns(ns, p) {
                 Ok(h) => h,
                 Err(e) => Hashes {
-                    file: p.to_path_buf(),
-                    error: Some(format!("{e}")),
-                    ..Default::default()
+                    file: p.to_path_buf().clone(),
+                    meta: FileMeta {
+                        error: Some(format!("{e}")),
+                        ..Default::default()
+                    },
                 },
             }
         } else {
             Hashes {
-                file: p.to_path_buf(),
-                error: Some("unknown namespace".into()),
-                ..Default::default()
+                file: p.to_path_buf().clone(),
+                meta: FileMeta {
+                    error: Some("unknown namespace".into()),
+                    ..Default::default()
+                },
             }
         }
     }
@@ -572,12 +616,14 @@ impl EventConsumer {
             ancestors: ancestors.join("|"),
             parent_exe: self.get_parent_image(&info),
             command_line: event.data.argv.to_command_line(),
-            exe: self.get_hashes_with_ns(opt_mnt_ns, &event.data.executable),
+            exe: self.get_hashes_with_ns(opt_mnt_ns, &cache::Path::from(&event.data.executable)),
             interpreter: None,
         };
 
         if event.data.executable != event.data.interpreter {
-            data.interpreter = Some(self.get_hashes_with_ns(opt_mnt_ns, &event.data.interpreter))
+            data.interpreter = Some(
+                self.get_hashes_with_ns(opt_mnt_ns, &cache::Path::from(&event.data.interpreter)),
+            )
         }
 
         UserEvent::new(data, info)
@@ -666,7 +712,7 @@ impl EventConsumer {
     ) -> UserEvent<kunai::events::MmapExecData> {
         let filename = event.data.filename;
         let opt_mnt_ns = Self::task_mnt_ns(&event.info);
-        let mmapped_hashes = self.get_hashes_with_ns(opt_mnt_ns, &filename);
+        let mmapped_hashes = self.get_hashes_with_ns(opt_mnt_ns, &cache::Path::from(&filename));
 
         let ck = info.task_key();
 
@@ -1073,7 +1119,7 @@ impl EventConsumer {
     #[inline]
     fn handle_hash_event(&mut self, info: StdEventInfo, event: &bpf_events::HashEvent) {
         let opt_mnt_ns = Self::task_mnt_ns(&info.info);
-        self.get_hashes_with_ns(opt_mnt_ns, &event.data.path);
+        self.get_hashes_with_ns(opt_mnt_ns, &cache::Path::from(&event.data.path));
     }
 
     fn build_std_event_info(&mut self, i: bpf_events::EventInfo) -> StdEventInfo {
@@ -1159,7 +1205,7 @@ impl EventConsumer {
             // Generally speaking killing action must be done with
             // care as sending a SIGKILL to a critical process
             // might impact the system.
-            if actions.contains("kill") {
+            if actions.contains(Actions::Kill.as_str()) {
                 let pid = event.info().task.pid;
                 // this is the kind of information we want to have
                 // at all time so we put this as a warning not to
@@ -1170,6 +1216,76 @@ impl EventConsumer {
                 }
             }
         }
+
+        // if action contains scan-file and if scan events are enabled
+        if self.scan_events_enabled && actions.contains(Actions::ScanFiles.as_str()) {
+            let _ = self
+                .action_scan_files(event)
+                .inspect_err(|e| error!("{} action failed: {e}", Actions::ScanFiles));
+        }
+    }
+
+    #[inline(always)]
+    fn file_scan_event<T: Serialize + KunaiEvent>(
+        &mut self,
+        event: &T,
+        ns: Namespace,
+        p: &Path,
+    ) -> UserEvent<FileScanData> {
+        // if the scanner is None, signatures will be an empty Vec
+        let (sigs, err) = match self.file_scanner.as_mut() {
+            Some(s) => match self
+                .cache
+                .get_sig_or_cache(ns, &cache::Path::from(p.to_path_buf()), s)
+            {
+                Ok(sigs) => (sigs, None),
+                Err(e) => (vec![], Some(format!("{e}"))),
+            },
+            None => (vec![], None),
+        };
+
+        let pos = sigs.len();
+        let mut data = FileScanData::from_hashes(
+            self.get_hashes_with_ns(Some(ns), &cache::Path::from(p.to_path_buf())),
+        );
+        data.source_event = event.info().event.uuid.clone();
+        data.signatures = sigs;
+        data.positives = pos;
+        data.scan_error = err;
+
+        let info = EventInfo::from_other_with_type(event.info().clone(), Type::FileScan);
+        UserEvent::with_data_and_info(data, info)
+    }
+
+    #[inline(always)]
+    fn action_scan_files<T: Serialize + KunaiEvent>(&mut self, event: &T) -> anyhow::Result<()> {
+        // this check prevents infinite loop for FileScan events
+        if event.info().event.id == Type::FileScan.id() {
+            return Ok(());
+        }
+
+        let ns = match event.info().task.namespaces.as_ref() {
+            Some(ns) => Namespace::mnt(ns.mnt),
+            None => return Err(anyhow!("namespace not found")),
+        };
+
+        for p in event.scannable_files() {
+            let mut event = self.file_scan_event(event, ns, &p);
+            // print a warning if a positive scan happens so that a trace
+            // is kept in system logs
+            if event.data.positives > 0 {
+                warn!(
+                    "file={} matches detection signatures={:?} triggered by event uuid={}",
+                    p.to_string_lossy(),
+                    &event.data.signatures,
+                    &event.info().event.uuid,
+                )
+            }
+            // we run through event scanning engine
+            self.scan_and_print(&mut event);
+        }
+
+        Ok(())
     }
 
     #[inline(always)]
@@ -1233,7 +1349,7 @@ impl EventConsumer {
             Type::Unknown => {
                 error!("Unknown event type: {}", etype as u64)
             }
-            Type::Max | Type::EndEvents | Type::TaskSched => {}
+            Type::Max | Type::EndConfigurable | Type::TaskSched | Type::FileScan => {}
             Type::Execve | Type::ExecveScript => {
                 match event!(enc_event, bpf_events::ExecveEvent) {
                     Ok(e) => {
@@ -1919,6 +2035,10 @@ struct RunOpt {
     /// File containing IoCs (json line).
     #[arg(short, long, value_name = "FILE")]
     ioc_file: Option<Vec<String>>,
+
+    /// Yara rules dir/file. Supersedes configuration file.
+    #[arg(short, long, value_name = "FILE")]
+    yara_rules: Option<Vec<String>>,
 }
 
 impl TryFrom<RunOpt> for Config {
@@ -1943,6 +2063,11 @@ impl TryFrom<RunOpt> for Config {
         // supersedes configuration
         if let Some(iocs) = opt.ioc_file {
             conf.iocs = iocs;
+        }
+
+        // supersedes configuration
+        if let Some(yara_rules) = opt.yara_rules {
+            conf.yara = yara_rules;
         }
 
         // supersedes configuration if true
@@ -2140,12 +2265,13 @@ impl Command {
                         Type::BpfProgLoad => scan_event!(p, BpfProgLoadData),
                         Type::BpfSocketFilter => scan_event!(p, BpfSocketFilterData),
                         Type::Exit | Type::ExitGroup => scan_event!(p, ExitData),
+                        Type::FileScan => scan_event!(p, FileScanData),
 
                         Type::Unknown
                         | Type::CacheHash
                         | Type::Correlation
                         | Type::Error
-                        | Type::EndEvents
+                        | Type::EndConfigurable
                         | Type::TaskSched
                         | Type::SyscoreResume
                         | Type::Max => {}
@@ -2211,16 +2337,21 @@ impl Command {
             .build()
             .unwrap();
 
+        // we start event reader and event processor before loading the programs
+        // if we load the programs first we might have some event lost errors
+        let (sender, mut receiver) = mpsc::channel(512);
+
+        // we start consumer
+        let mut cons = EventConsumer::with_config(conf.clone())?;
+        let mut cons_task = runtime.spawn(async move {
+            while let Some(mut enc) = receiver.recv().await {
+                cons.handle_event(&mut enc);
+            }
+
+            Ok::<(), anyhow::Error>(())
+        });
+
         runtime.block_on(async move {
-            // we start event reader and event processor before loading the programs
-            // if we load the programs first we might have some event lost errors
-            let (sender, receiver) = mpsc::channel(512);
-
-            // we start consumer
-            let cons = EventConsumer::with_config(conf.clone())?
-                .consume(receiver)
-                .await?;
-
             // we spawn a task to reload producer when needed
             let main = async move {
                 loop {
@@ -2249,14 +2380,10 @@ impl Command {
 
                         // we check if task spawned by consumer failed
                         // if yes we make it panic
-                        let mut cons = cons.write().await;
-                        if let Ok(res) =
-                            timeout(Duration::from_nanos(1), cons.task.as_mut().unwrap()).await
-                        {
+                        let cons = &mut cons_task;
+                        if let Ok(res) = timeout(Duration::from_nanos(1), cons).await {
                             res.unwrap().unwrap();
                         }
-                        // don't keep lock on consumer
-                        drop(cons);
 
                         // we check if a task spawned by the producer failed
                         // if yes we make it panic

--- a/kunai/src/cache.rs
+++ b/kunai/src/cache.rs
@@ -1,6 +1,7 @@
 use gene::{FieldGetter, FieldValue};
 use gene_derive::FieldGetter;
 
+use kunai_common::time::Time;
 use lru_st::collections::LruHashMap;
 use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
@@ -12,12 +13,18 @@ use std::{
     fs::File,
     io::{self, BufReader, Read},
     os::unix::prelude::MetadataExt,
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::SystemTime,
 };
 use thiserror::Error;
 
-use crate::util::namespaces::{self, Kind, Namespace, Switcher};
+use crate::{
+    util::{
+        defer::defer,
+        namespaces::{self, Kind, Namespace, Switcher},
+    },
+    yara::Scanner,
+};
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -35,11 +42,12 @@ pub enum Error {
     MetadataRequired,
     #[error("file not found")]
     FileNotFound,
+    #[error("yara scan error: {0}")]
+    ScanError(#[from] yara_x::errors::ScanError),
 }
 
 #[derive(Debug, Default, Clone, FieldGetter, Serialize, Deserialize)]
-pub struct Hashes {
-    pub file: PathBuf,
+pub struct FileMeta {
     pub md5: String,
     pub sha1: String,
     pub sha256: String,
@@ -49,8 +57,27 @@ pub struct Hashes {
     pub error: Option<String>,
 }
 
+impl FileMeta {
+    #[inline]
+    pub(crate) fn iocs(&self) -> Vec<Cow<'_, str>> {
+        vec![
+            self.md5.as_str().into(),
+            self.sha1.as_str().into(),
+            self.sha256.as_str().into(),
+            self.sha512.as_str().into(),
+        ]
+    }
+}
+
+#[derive(Debug, Default, Clone, FieldGetter, Serialize, Deserialize)]
+pub struct Hashes {
+    pub file: PathBuf,
+    #[serde(flatten)]
+    pub meta: FileMeta,
+}
+
 impl Hashes {
-    pub fn from_path_ref<T: AsRef<Path>>(p: T) -> Self {
+    pub fn from_path_ref<T: AsRef<std::path::Path>>(p: T) -> Self {
         let path = p.as_ref();
         let mut h = Hashes {
             file: path.to_path_buf(),
@@ -72,13 +99,13 @@ impl Hashes {
                 sha1.update(&buf[..n]);
                 sha256.update(&buf[..n]);
                 sha512.update(&buf[..n]);
-                h.size += n;
+                h.meta.size += n;
             }
 
-            h.md5 = hex::encode(md5.finalize());
-            h.sha1 = hex::encode(sha1.finalize());
-            h.sha256 = hex::encode(sha256.finalize());
-            h.sha512 = hex::encode(sha512.finalize());
+            h.meta.md5 = hex::encode(md5.finalize());
+            h.meta.sha1 = hex::encode(sha1.finalize());
+            h.meta.sha256 = hex::encode(sha256.finalize());
+            h.meta.sha512 = hex::encode(sha512.finalize());
         }
 
         h
@@ -86,13 +113,51 @@ impl Hashes {
 
     #[inline]
     pub(crate) fn iocs(&self) -> Vec<Cow<'_, str>> {
-        vec![
-            self.file.to_string_lossy(),
-            self.md5.as_str().into(),
-            self.sha1.as_str().into(),
-            self.sha256.as_str().into(),
-            self.sha512.as_str().into(),
-        ]
+        let mut v = vec![self.file.to_string_lossy()];
+        v.extend(self.meta.iocs());
+        v
+    }
+}
+
+/// Path enum used as a generic interface to handle both
+/// path comming from eBPF and path comming from std lib
+#[derive(Debug)]
+pub enum Path {
+    Bpf {
+        path: std::path::PathBuf,
+        ebpf_meta: Option<kunai_common::path::Metadata>,
+    },
+    Std(std::path::PathBuf),
+}
+
+impl From<std::path::PathBuf> for Path {
+    fn from(value: std::path::PathBuf) -> Self {
+        Self::Std(value)
+    }
+}
+
+impl From<&str> for Path {
+    fn from(value: &str) -> Self {
+        Self::Std(PathBuf::from(value))
+    }
+}
+
+impl From<&kunai_common::path::Path> for Path {
+    fn from(value: &kunai_common::path::Path) -> Self {
+        Self::Bpf {
+            path: value.to_path_buf(),
+            ebpf_meta: value.metadata,
+        }
+    }
+}
+
+impl Path {
+    #[inline]
+    pub fn to_path_buf(&self) -> &PathBuf {
+        match self {
+            Self::Bpf { path, ebpf_meta: _ } => path,
+            Self::Std(p) => p,
+        }
     }
 }
 
@@ -120,10 +185,7 @@ impl Default for Key {
 }
 
 impl Key {
-    fn from_ebpf_path_ref_with_ns(
-        ns: &Namespace,
-        path: &kunai_common::path::Path,
-    ) -> Result<Self, Error> {
+    fn from_path_with_ns(ns: &Namespace, path: &Path) -> Result<Self, Error> {
         let pb = path.to_path_buf();
 
         // checking if the file still exists
@@ -133,29 +195,33 @@ impl Key {
 
         let meta = pb.metadata()?;
 
-        let mut k = Key {
+        let k = Key {
             mnt_namespace: ns.inum,
-            path: path.to_path_buf(),
+            path: pb.clone(),
+            size: meta.size(),
+            modified: SystemTime::from(&Time::new(meta.mtime(), meta.mtime_nsec())),
+            accessed: SystemTime::from(&Time::new(meta.atime(), meta.atime_nsec())),
             ..Default::default()
         };
 
-        // we don't have to switch to ns here as it is done in caller
-        let ebpf_meta = path.metadata.ok_or(Error::MetadataRequired)?;
-        k.size = ebpf_meta.size as u64;
-        k.modified = ebpf_meta.mtime.into_system_time();
-        k.accessed = ebpf_meta.atime.into_system_time();
+        // we do extra checks if it is a Path comming from our probes
+        // this way we can catch eventual file tampering attempts
+        if let Path::Bpf { path: _, ebpf_meta } = path {
+            // we don't have to switch to ns here as it is done in caller
+            let ebpf_meta = ebpf_meta.ok_or(Error::MetadataRequired)?;
 
-        if k.size != meta.size() {
-            return Err(Error::FileModSinceKernelEvent("sized changed"));
-        }
+            if k.size != meta.size() {
+                return Err(Error::FileModSinceKernelEvent("size changed"));
+            }
 
-        if ebpf_meta.ino != meta.ino() {
-            return Err(Error::FileModSinceKernelEvent("inode changed"));
-        }
+            if ebpf_meta.ino != meta.ino() {
+                return Err(Error::FileModSinceKernelEvent("inode changed"));
+            }
 
-        if let Ok(mtime) = meta.modified() {
-            if mtime != k.modified {
-                return Err(Error::FileModSinceKernelEvent("mtime changed"));
+            if let Ok(mtime) = meta.modified() {
+                if mtime != k.modified {
+                    return Err(Error::FileModSinceKernelEvent("mtime changed"));
+                }
             }
         }
 
@@ -173,6 +239,11 @@ struct CachedNs {
 pub struct Cache {
     namespaces: HashMap<Namespace, CachedNs>,
     hashes: LruHashMap<Key, Hashes>,
+    // since hashes and signatures are not computed
+    // at the same time. It seems a better option
+    // to separate into two HashMaps to prevent
+    // any race
+    signatures: LruHashMap<Key, Vec<String>>,
 }
 
 impl Cache {
@@ -181,6 +252,7 @@ impl Cache {
         Cache {
             namespaces: HashMap::new(),
             hashes: LruHashMap::with_max_entries(cap),
+            signatures: LruHashMap::with_max_entries(cap),
         }
     }
 
@@ -193,11 +265,58 @@ impl Cache {
     }
 
     #[inline]
-    pub fn get_or_cache_in_ns(
+    pub fn get_sig_or_cache(
         &mut self,
         ns: Namespace,
-        path: &kunai_common::path::Path,
-    ) -> Result<Hashes, Error> {
+        path: &Path,
+        scanner: &mut Scanner<'_>,
+    ) -> Result<Vec<String>, Error> {
+        // check that the namespace is a mount namespace
+        if !ns.is_kind(Kind::Mnt) {
+            return Err(Error::WrongNsKind {
+                exp: Kind::Mnt,
+                got: ns.kind,
+            });
+        }
+
+        let Some(entry) = self.namespaces.get(&ns) else {
+            return Err(Error::UnknownNs(ns));
+        };
+
+        // we switch to a cached namespace that holds opened
+        // file descriptors to namespaces
+        entry.switcher.enter()?;
+        // we must be sure that we restore our namespace
+        defer!(|| { entry.switcher.exit().expect("failed to restore namespace") });
+
+        // we get a PathBuf as path ownership is passed down
+        let pb = path.to_path_buf();
+        // we create key to check if we already have cached
+        // signatures for that file
+        let key = Key::from_path_with_ns(&ns, path)?;
+
+        let sigs = match self.signatures.get(&key) {
+            // we have caches signatures
+            Some(sig) => sig.clone(),
+            // we don't have cached signatures
+            None => {
+                let mut sigs = vec![];
+                // lock should never fail as the scanner is used only in one thread
+                let mut yx_scanner = scanner.lock().expect("failed to lock yara scanner");
+                let sr = yx_scanner.scan_file(pb)?;
+                // we extend the list of signatures
+                sigs.extend(sr.matching_rules().map(|m| m.identifier().to_string()));
+                // we update our cache
+                self.signatures.insert(key.clone(), sigs.clone());
+                sigs
+            }
+        };
+
+        Ok(sigs)
+    }
+
+    #[inline]
+    pub fn get_or_cache_in_ns(&mut self, ns: Namespace, path: &Path) -> Result<Hashes, Error> {
         // check that the namespace is a mount namespace
         if !ns.is_kind(Kind::Mnt) {
             return Err(Error::WrongNsKind {
@@ -212,9 +331,12 @@ impl Cache {
 
         // we switch to namespace
         entry.switcher.enter()?;
+        // we must be sure that we restore our namespace
+        defer!(|| { entry.switcher.exit().expect("failed to restore namespace") });
+
         let pb = path.to_path_buf();
 
-        let key = Key::from_ebpf_path_ref_with_ns(&ns, path)?;
+        let key = Key::from_path_with_ns(&ns, path)?;
 
         if !self.hashes.contains_key(&key) {
             let h = Hashes::from_path_ref(pb);
@@ -223,9 +345,6 @@ impl Cache {
 
         // we cannot panic here as we are sure the cache contains value
         let res = Ok(self.hashes.get(&key).unwrap().clone());
-
-        // we must be sure that we restore our namespace
-        entry.switcher.exit().expect("failed to restore namespace");
 
         res
     }

--- a/kunai/src/cache.rs
+++ b/kunai/src/cache.rs
@@ -146,11 +146,11 @@ impl Key {
         k.accessed = ebpf_meta.atime.into_system_time();
 
         if k.size != meta.size() {
-            return Err(Error::FileModSinceKernelEvent("inode changed"));
+            return Err(Error::FileModSinceKernelEvent("sized changed"));
         }
 
         if ebpf_meta.ino != meta.ino() {
-            return Err(Error::FileModSinceKernelEvent("sized changed"));
+            return Err(Error::FileModSinceKernelEvent("inode changed"));
         }
 
         if let Ok(mtime) = meta.modified() {

--- a/kunai/src/config.rs
+++ b/kunai/src/config.rs
@@ -26,16 +26,24 @@ pub struct Event {
 }
 
 impl Event {
+    #[inline(always)]
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    #[inline(always)]
     pub fn disable(&mut self) {
         self.enable = false
     }
 
+    #[inline(always)]
     pub fn enable(&mut self) {
         self.enable = true
+    }
+
+    #[inline(always)]
+    pub fn is_enabled(&self) -> bool {
+        self.enable
     }
 }
 
@@ -56,6 +64,7 @@ pub struct Config {
     pub send_data_min_len: Option<u64>,
     pub rules: Vec<String>,
     pub iocs: Vec<String>,
+    pub yara: Vec<String>,
     pub harden: bool,
     pub events: Vec<Event>,
 }
@@ -84,6 +93,7 @@ impl Default for Config {
             send_data_min_len: None,
             rules: vec![],
             iocs: vec![],
+            yara: vec![],
             harden: false,
             events,
         }

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -48,18 +48,18 @@ impl From<ContainerInfo> for ContainerSection {
 #[derive(FieldGetter, Serialize, Deserialize)]
 pub struct HostSection {
     #[getter(skip)]
-    uuid: uuid::Uuid,
-    name: String,
-    container: Option<ContainerSection>,
+    pub uuid: uuid::Uuid,
+    pub name: String,
+    pub container: Option<ContainerSection>,
 }
 
 #[derive(FieldGetter, Serialize, Deserialize)]
 pub struct EventSection {
-    source: String,
-    id: u32,
-    name: String,
-    uuid: String,
-    batch: usize,
+    pub source: String,
+    pub id: u32,
+    pub name: String,
+    pub uuid: String,
+    pub batch: usize,
 }
 
 impl From<&StdEventInfo> for EventSection {
@@ -87,15 +87,15 @@ impl From<kunai_common::bpf_events::Namespaces> for NamespaceInfo {
 
 #[derive(Debug, FieldGetter, Serialize, Deserialize)]
 pub struct TaskSection {
-    name: String,
-    pid: i32,
-    tgid: i32,
-    guuid: String,
-    uid: u32,
-    gid: u32,
-    namespaces: Option<NamespaceInfo>,
+    pub name: String,
+    pub pid: i32,
+    pub tgid: i32,
+    pub guuid: String,
+    pub uid: u32,
+    pub gid: u32,
+    pub namespaces: Option<NamespaceInfo>,
     #[serde(with = "u32_hex")]
-    flags: u32,
+    pub flags: u32,
 }
 
 impl From<kunai_common::bpf_events::TaskInfo> for TaskSection {
@@ -281,6 +281,8 @@ impl ScanResult {
 
 pub trait KunaiEvent: ::gene::Event + ::gene::FieldGetter + IocGetter {
     fn set_detection(&mut self, sr: ScanResult);
+    fn get_detection(&self) -> &Option<ScanResult>;
+    fn info(&self) -> &EventInfo;
 }
 
 #[derive(Event, FieldGetter, Serialize, Deserialize)]
@@ -305,8 +307,19 @@ impl<T> KunaiEvent for UserEvent<T>
 where
     T: FieldGetter + IocGetter,
 {
+    #[inline(always)]
     fn set_detection(&mut self, sr: ScanResult) {
         self.detection = Some(sr)
+    }
+
+    #[inline(always)]
+    fn get_detection(&self) -> &Option<ScanResult> {
+        &self.detection
+    }
+
+    #[inline(always)]
+    fn info(&self) -> &EventInfo {
+        &self.info
     }
 }
 

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -9,10 +9,12 @@ use chrono::{DateTime, FixedOffset, SecondsFormat, Utc};
 use gene::{Event, FieldGetter, FieldValue};
 use gene_derive::{Event, FieldGetter};
 
+use kunai_common::bpf_events;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
 
 use crate::{
-    cache::Hashes,
+    cache::{FileMeta, Hashes},
     containers::Container,
     info::{ContainerInfo, StdEventInfo},
 };
@@ -28,7 +30,7 @@ impl From<PathBuf> for File {
     }
 }
 
-#[derive(FieldGetter, Serialize, Deserialize)]
+#[derive(FieldGetter, Serialize, Deserialize, Clone)]
 #[getter(use_serde_rename)]
 pub struct ContainerSection {
     pub name: String,
@@ -45,7 +47,7 @@ impl From<ContainerInfo> for ContainerSection {
     }
 }
 
-#[derive(FieldGetter, Serialize, Deserialize)]
+#[derive(FieldGetter, Serialize, Deserialize, Clone)]
 pub struct HostSection {
     #[getter(skip)]
     pub uuid: uuid::Uuid,
@@ -53,7 +55,7 @@ pub struct HostSection {
     pub container: Option<ContainerSection>,
 }
 
-#[derive(FieldGetter, Serialize, Deserialize)]
+#[derive(FieldGetter, Serialize, Deserialize, Clone)]
 pub struct EventSection {
     pub source: String,
     pub id: u32,
@@ -74,9 +76,9 @@ impl From<&StdEventInfo> for EventSection {
     }
 }
 
-#[derive(Debug, FieldGetter, Serialize, Deserialize)]
+#[derive(Debug, FieldGetter, Serialize, Deserialize, Clone)]
 pub struct NamespaceInfo {
-    mnt: u32,
+    pub mnt: u32,
 }
 
 impl From<kunai_common::bpf_events::Namespaces> for NamespaceInfo {
@@ -85,7 +87,7 @@ impl From<kunai_common::bpf_events::Namespaces> for NamespaceInfo {
     }
 }
 
-#[derive(Debug, FieldGetter, Serialize, Deserialize)]
+#[derive(Debug, FieldGetter, Serialize, Deserialize, Clone)]
 pub struct TaskSection {
     pub name: String,
     pub pid: i32,
@@ -113,6 +115,7 @@ impl From<kunai_common::bpf_events::TaskInfo> for TaskSection {
     }
 }
 
+#[derive(Clone)]
 pub struct UtcDateTime(DateTime<Utc>);
 
 impl From<DateTime<Utc>> for UtcDateTime {
@@ -173,7 +176,7 @@ impl FieldGetter for UtcDateTime {
     }
 }
 
-#[derive(FieldGetter, Serialize, Deserialize)]
+#[derive(FieldGetter, Serialize, Deserialize, Clone)]
 pub struct EventInfo {
     pub host: HostSection,
     pub event: EventSection,
@@ -205,8 +208,25 @@ impl From<StdEventInfo> for EventInfo {
     }
 }
 
+impl EventInfo {
+    pub fn from_other_with_type(mut other: EventInfo, ty: bpf_events::Type) -> Self {
+        other.event.name = ty.to_string();
+        other.event.id = ty.id();
+        other.event.uuid = Uuid::new_v4().to_string();
+        other
+    }
+}
+
+/// Trait providing a function returning all the IoCs
+/// the implementer can provide for IoC checking purposes.
 pub trait IocGetter {
     fn iocs(&mut self) -> Vec<Cow<'_, str>>;
+}
+
+/// Trait to represent the fact that an event may be
+/// scanned by a file scanner.
+pub trait Scannable {
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>>;
 }
 
 macro_rules! impl_std_iocs {
@@ -279,7 +299,7 @@ impl ScanResult {
     }
 }
 
-pub trait KunaiEvent: ::gene::Event + ::gene::FieldGetter + IocGetter {
+pub trait KunaiEvent: ::gene::Event + ::gene::FieldGetter + IocGetter + Scannable {
     fn set_detection(&mut self, sr: ScanResult);
     fn get_detection(&self) -> &Option<ScanResult>;
     fn info(&self) -> &EventInfo;
@@ -298,14 +318,25 @@ impl<T> IocGetter for UserEvent<T>
 where
     T: IocGetter,
 {
+    #[inline(always)]
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         self.data.iocs()
     }
 }
 
+impl<T> Scannable for UserEvent<T>
+where
+    T: Scannable,
+{
+    #[inline(always)]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        self.data.scannable_files()
+    }
+}
+
 impl<T> KunaiEvent for UserEvent<T>
 where
-    T: FieldGetter + IocGetter,
+    T: FieldGetter + IocGetter + Scannable,
 {
     #[inline(always)]
     fn set_detection(&mut self, sr: ScanResult) {
@@ -329,6 +360,14 @@ impl<T> UserEvent<T> {
             data,
             detection: None,
             info: info.into(),
+        }
+    }
+
+    pub fn with_data_and_info(data: T, info: EventInfo) -> Self {
+        Self {
+            data,
+            detection: None,
+            info,
         }
     }
 }
@@ -429,6 +468,17 @@ pub struct ExecveData {
     pub interpreter: Option<Hashes>,
 }
 
+impl Scannable for ExecveData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        let mut v = vec![Cow::Borrowed(&self.exe.file)];
+        if let Some(interp) = self.interpreter.as_ref() {
+            v.push(Cow::Borrowed(&interp.file));
+        }
+        v
+    }
+}
+
 impl IocGetter for ExecveData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         // parent_exe path
@@ -453,6 +503,13 @@ def_user_data!(
     }
 );
 
+impl Scannable for CloneData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 impl_std_iocs!(CloneData);
 
 def_user_data!(
@@ -472,6 +529,13 @@ def_user_data!(
 
 impl_std_iocs!(PrctlData);
 
+impl Scannable for PrctlData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 #[derive(Debug, FieldGetter, Serialize, Deserialize)]
 pub struct TargetTask {
     pub command_line: String,
@@ -486,6 +550,13 @@ def_user_data!(
     }
 );
 
+impl Scannable for KillData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 impl_std_iocs!(KillData);
 
 def_user_data!(
@@ -493,6 +564,16 @@ def_user_data!(
         pub mapped: Hashes,
     }
 );
+
+impl Scannable for MmapExecData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![
+            Cow::Borrowed(&self.exe.file),
+            Cow::Borrowed(&self.mapped.file),
+        ]
+    }
+}
 
 impl IocGetter for MmapExecData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
@@ -510,6 +591,13 @@ def_user_data!(
         pub prot: u64,
     }
 );
+
+impl Scannable for MprotectData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
 
 impl_std_iocs!(MprotectData);
 
@@ -553,6 +641,13 @@ def_user_data!(
         pub connected: bool,
     }
 );
+
+impl Scannable for ConnectData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
 
 impl IocGetter for ConnectData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
@@ -601,6 +696,13 @@ impl DnsQueryData {
     }
 }
 
+impl Scannable for DnsQueryData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 impl IocGetter for DnsQueryData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         // we build up responses if needed
@@ -631,6 +733,13 @@ def_user_data!(
     }
 );
 
+impl Scannable for SendDataData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 impl IocGetter for SendDataData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         let mut v = vec![self.exe.file.to_string_lossy()];
@@ -656,6 +765,13 @@ impl IocGetter for InitModuleData {
     }
 }
 
+impl Scannable for InitModuleData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 def_user_data!(
     pub struct RWData {
         pub path: PathBuf,
@@ -665,6 +781,13 @@ def_user_data!(
 impl IocGetter for RWData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         vec![self.exe.file.to_string_lossy(), self.path.to_string_lossy()]
+    }
+}
+
+impl Scannable for RWData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file), Cow::Borrowed(&self.path)]
     }
 }
 
@@ -678,6 +801,13 @@ def_user_data!(
 impl IocGetter for UnlinkData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         vec![self.exe.file.to_string_lossy(), self.path.to_string_lossy()]
+    }
+}
+
+impl Scannable for UnlinkData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
     }
 }
 
@@ -695,6 +825,13 @@ impl IocGetter for FileRenameData {
             self.old.to_string_lossy(),
             self.new.to_string_lossy(),
         ]
+    }
+}
+
+impl Scannable for FileRenameData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file), Cow::Borrowed(&self.new)]
     }
 }
 
@@ -739,6 +876,13 @@ impl IocGetter for BpfProgLoadData {
     }
 }
 
+impl Scannable for BpfProgLoadData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 #[derive(Debug, FieldGetter, Serialize, Deserialize)]
 pub struct SocketInfo {
     pub domain: String,
@@ -764,6 +908,13 @@ def_user_data!(
     }
 );
 
+impl Scannable for BpfSocketFilterData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 impl IocGetter for BpfSocketFilterData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         vec![
@@ -782,4 +933,50 @@ def_user_data!(
     }
 );
 
+impl Scannable for ExitData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.file)]
+    }
+}
+
 impl_std_iocs!(ExitData);
+
+#[derive(Default, Debug, Serialize, Deserialize, FieldGetter)]
+pub struct FileScanData {
+    pub file: PathBuf,
+    pub meta: FileMeta,
+    #[getter(skip)]
+    pub signatures: Vec<String>,
+    pub positives: usize,
+    pub source_event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scan_error: Option<String>,
+}
+
+impl FileScanData {
+    pub fn from_hashes(h: Hashes) -> Self {
+        Self {
+            file: h.file,
+            meta: h.meta,
+            ..Default::default()
+        }
+    }
+}
+
+impl Scannable for FileScanData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![]
+    }
+}
+
+impl IocGetter for FileScanData {
+    // we might want to scan hashes against IoCs later than execve
+    #[inline(always)]
+    fn iocs(&mut self) -> Vec<Cow<'_, str>> {
+        let mut v = vec![self.file.to_string_lossy()];
+        v.extend(self.meta.iocs());
+        v
+    }
+}

--- a/kunai/src/lib.rs
+++ b/kunai/src/lib.rs
@@ -11,6 +11,7 @@ pub mod events;
 pub mod info;
 pub mod ioc;
 pub mod util;
+pub mod yara;
 
 /// function that responsible of probe priorities and compatibily across kernels
 /// panic: if a given probe name is not found

--- a/kunai/src/util.rs
+++ b/kunai/src/util.rs
@@ -72,6 +72,13 @@ pub fn getrandom<T: Sized>() -> Result<T, RandError> {
     Ok(unsafe { t.assume_init() })
 }
 
+pub fn kill(pid: i32, sig: i32) -> Result<(), io::Error> {
+    if unsafe { libc::kill(pid, sig) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 #[inline]
 pub fn md5_data<T: AsRef<[u8]>>(data: T) -> String {
     let mut h = Md5::new();

--- a/kunai/src/util.rs
+++ b/kunai/src/util.rs
@@ -6,6 +6,7 @@ use sha2::{Sha256, Sha512};
 use std::{fs, io, net::IpAddr};
 
 pub mod bpf;
+pub mod defer;
 pub mod elf;
 pub mod namespaces;
 pub mod uname;

--- a/kunai/src/util/defer.rs
+++ b/kunai/src/util/defer.rs
@@ -1,0 +1,39 @@
+pub struct Defer<F: FnOnce()>(Option<F>);
+
+impl<F: FnOnce()> From<F> for Defer<F> {
+    fn from(value: F) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl<F: FnOnce()> Drop for Defer<F> {
+    fn drop(&mut self) {
+        if let Some(f) = self.0.take() {
+            f();
+        }
+    }
+}
+
+macro_rules! defer {
+    ($fn_once:expr) => {
+        let _defer = $crate::util::defer::Defer::from($fn_once);
+    };
+}
+
+pub(crate) use defer;
+
+#[cfg(test)]
+mod test {
+    use crate::util::defer::{defer, Defer};
+
+    #[test]
+    fn test_defer() {
+        defer!(|| { println!("test") });
+
+        let _defer = Defer(Some(|| {
+            println!("This is deferred and will run when the scope ends!");
+        }));
+
+        println!("Doing some work...");
+    }
+}

--- a/kunai/src/yara.rs
+++ b/kunai/src/yara.rs
@@ -1,0 +1,135 @@
+use std::{
+    fs, io,
+    marker::PhantomPinned,
+    ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Mutex,
+};
+
+/// yara-x uses a lot of lifetimes, which makes it hard to integrate
+/// in existing code. So this module mainly redefines easier types
+/// to work with.
+
+/// Wraps a yara_x::Rules, but preventing it from moving around in memory.
+struct PinnedRules {
+    rules: yara_x::Rules,
+    _pin: PhantomPinned,
+}
+
+/// Yara-x Scanner wrapper owning its own Rules and
+/// preventing some lifetime related issues
+pub struct Scanner<'a> {
+    scanner: Mutex<yara_x::Scanner<'a>>,
+    // This allows MyScanner to own the yara_x::Rules and pass a reference to the
+    // scanner. The use of `Pin` guarantees that the rules won't be moved.
+    _rules: Pin<Box<PinnedRules>>,
+}
+
+pub struct SourceCode {
+    content: String,
+    path: PathBuf,
+    _pin: PhantomPinned,
+}
+
+impl SourceCode {
+    pub fn from_rule_file<P: AsRef<Path>>(p: P) -> Result<Self, io::Error> {
+        Ok(SourceCode {
+            content: fs::read_to_string(&p)?,
+            path: p.as_ref().to_path_buf(),
+            _pin: PhantomPinned,
+        })
+    }
+
+    pub fn to_native(&self) -> yara_x::SourceCode<'_> {
+        yara_x::SourceCode::from(self.content.as_str()).with_origin(&self.path.to_string_lossy())
+    }
+}
+
+impl<'a> Scanner<'a> {
+    pub fn with_rules(rules: yara_x::Rules) -> Self {
+        let pinned_rules = Box::pin(PinnedRules {
+            rules,
+            _pin: PhantomPinned,
+        });
+        let rules_ptr = std::ptr::from_ref(&pinned_rules.rules);
+        let rules_ref = unsafe { rules_ptr.as_ref().unwrap() };
+        let scanner = yara_x::Scanner::new(rules_ref);
+
+        Self {
+            scanner: scanner.into(),
+            _rules: pinned_rules,
+        }
+    }
+}
+
+unsafe impl<'s> Send for Scanner<'s> {}
+
+impl<'s> Deref for Scanner<'s> {
+    type Target = Mutex<yara_x::Scanner<'s>>;
+    fn deref(&self) -> &Self::Target {
+        &self.scanner
+    }
+}
+
+impl<'s> DerefMut for Scanner<'s> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.scanner
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Write;
+
+    use super::{Scanner, SourceCode};
+
+    #[test]
+    fn test_scanner() {
+        let mut c = yara_x::Compiler::new();
+        // Add some YARA source code to compile.
+        c.add_source(
+            r#"
+    rule lorem_ipsum {
+      strings:
+        $ = "Lorem ipsum"
+      condition:
+        all of them
+    }
+"#,
+        )
+        .unwrap();
+        let s = Scanner::with_rules(c.build());
+        s.lock().unwrap().scan(b"Lorem ipsum").unwrap();
+    }
+
+    #[test]
+    fn test_source() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+
+        tmp.write_all(
+            r#"
+    rule lorem_ipsum {
+      strings:
+        $ = "Lorem ipsum"
+      condition:
+        all of them
+    }
+"#
+            .as_bytes(),
+        )
+        .unwrap();
+
+        let s = SourceCode::from_rule_file(tmp.path()).unwrap();
+
+        assert_eq!(s.path, tmp.path().to_path_buf());
+
+        let mut c = yara_x::Compiler::new();
+
+        // Add some YARA source code to compile.
+        c.add_source(s.to_native()).unwrap();
+
+        let s = Scanner::with_rules(c.build());
+        s.lock().unwrap().scan(b"Lorem ipsum").unwrap();
+    }
+}

--- a/scripts/ci/test_kernel.sh
+++ b/scripts/ci/test_kernel.sh
@@ -9,7 +9,7 @@ initramfs=${tmp_dir}/initramfs.img
 
 
 # building initramfs with our test binary as init
-cp target/x86_64-unknown-linux-musl/release/tests $tmp_dir/init
+cp target/x86_64-unknown-linux-gnu/release/tests $tmp_dir/init
 echo "init" | cpio -D $tmp_dir -o -H newc > $initramfs
 
 distro="ubuntu"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,6 @@
 mod ebpf;
 mod user;
+mod utils;
 
 use std::fs;
 use std::path::PathBuf;

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -1,0 +1,11 @@
+use std::env::VarError;
+
+pub(crate) fn vec_rustflags() -> Result<Vec<String>, anyhow::Error> {
+    match std::env::var("RUSTFLAGS") {
+        Ok(s) => Ok(vec![s]),
+        Err(e) => match e {
+            VarError::NotPresent => Ok(vec![]),
+            _ => Err(e.into()),
+        },
+    }
+}


### PR DESCRIPTION
This PR contains the first implementation of action (defined in detection rules) handling.
It also includes all the work concerning [yara-x](https://virustotal.github.io/yara-x/) integration.
For the moment only two actions are supported and implemented in this PR:

- Kill process via `kill` action keyword
- Scan a file via `scan-files` action keyword

Here are a couple of implementation details. 

- When a file is scanned a dedicated event (named `file_scan`) containing file metadata and signatures will be generated
  - If the yara engine contains no rule, only metadata will be populated in the event
- Once generated a `file_scan` event will make a trip into the Kunai events scanning engine. This makes possible any classical filter/detection rule to match on `file_scan`. So thanks to this it is possible to define actions to take on positive scans. 
- Why `scan-files` action keyword is plural ? Because in some events there might be several files to scan. For example in `mmap_exec` event we want to be able to scan both the executable running and the one memory mapped.

Notes: due to `yara-x` integration, many changes needed to be done in the way the project is compiled. This includes changing the way we compile statically but also the default compilation targets in `xtask`.