### PR TITLE
fix #70: making IoC severity configurable

### DIFF
--- a/kunai/src/ioc.rs
+++ b/kunai/src/ioc.rs
@@ -5,4 +5,5 @@ pub struct IoC {
     pub source: String,
     pub uuid: uuid::Uuid,
     pub value: String,
+    pub severity: u8,
 }


### PR DESCRIPTION
The new IoC format needs to contain a `severity` field. In this way, anyone is free to define the severity of an IoC based on its own criteria.

```json
{
  "uuid": "ce473a0c-acf3-497b-bf35-cf534a1b69fa",
  "source": "CIRCL OSINT Feed",
  "value": "3proxy.ru",
  "event_uuid": "d67bfbe0-e01d-4e2e-8a56-214805d85aee",
  "severity": 7
}
```

Notes: 
- `severity` field is mandatory
- if the same IoC (by value) appears several times in the configuration file only the maximum severity will be kept 
- the script in kunai tools repository will be updated to ship IoCs with default severity