### PR TITLE
feat: new write_and_close event

### DIFF
--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -112,6 +112,8 @@ pub enum Type {
     FileRename,
     #[str("file_unlink")]
     FileUnlink,
+    #[str("write_and_close")]
+    WriteAndClose,
 
     // specific userland events
     // those should never be used in eBPF

--- a/kunai-common/src/bpf_events/events.rs
+++ b/kunai-common/src/bpf_events/events.rs
@@ -74,9 +74,11 @@ const fn max_bpf_event_size() -> usize {
             Type::Connect => ConnectEvent::size_of(),
             Type::DnsQuery => DnsQueryEvent::size_of(),
             Type::SendData => SendEntropyEvent::size_of(),
-            Type::Read | Type::ReadConfig | Type::Write | Type::WriteConfig => {
-                ConfigEvent::size_of()
-            }
+            Type::Read
+            | Type::ReadConfig
+            | Type::Write
+            | Type::WriteConfig
+            | Type::WriteAndClose => FileEvent::size_of(),
             Type::FileRename => FileRenameEvent::size_of(),
             Type::FileUnlink => UnlinkEvent::size_of(),
             Type::Error => ErrorEvent::size_of(),

--- a/kunai-common/src/bpf_events/events/fs.rs
+++ b/kunai-common/src/bpf_events/events/fs.rs
@@ -1,10 +1,10 @@
 use crate::bpf_events::Event;
 use crate::path::Path;
 
-pub type ConfigEvent = Event<ConfigData>;
+pub type FileEvent = Event<FileData>;
 
 #[repr(C)]
-pub struct ConfigData {
+pub struct FileData {
     pub path: Path,
 }
 

--- a/kunai-common/src/config/bpf.rs
+++ b/kunai-common/src/config/bpf.rs
@@ -14,11 +14,18 @@ pub unsafe fn config() -> Option<&'static BpfConfig> {
 }
 
 impl BpfConfig {
+    #[inline(always)]
     pub unsafe fn current_is_loader(&self) -> bool {
         bpf_get_current_pid_tgid() as u32 == self.loader.tgid
     }
 
+    #[inline(always)]
     pub fn is_event_enabled(&self, ty: bpf_events::Type) -> bool {
         self.filter.is_enabled(ty)
+    }
+
+    #[inline(always)]
+    pub fn is_event_disabled(&self, ty: bpf_events::Type) -> bool {
+        !self.filter.is_enabled(ty)
     }
 }

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1589,15 +1589,17 @@ impl<'s> EventConsumer<'s> {
                 Err(e) => error!("failed to decode {} event: {:?}", etype, e),
             },
 
-            Type::WriteConfig | Type::Write | Type::ReadConfig | Type::Read => {
-                match event!(enc_event, bpf_events::ConfigEvent) {
-                    Ok(e) => {
+            Type::WriteConfig
+            | Type::Write
+            | Type::ReadConfig
+            | Type::Read
+            | Type::WriteAndClose => match event!(enc_event, bpf_events::FileEvent) {
+                Ok(e) => {
                     let mut e = self.file_event(std_info, e);
-                        self.scan_and_print(&mut e);
-                    }
-                    Err(e) => error!("failed to decode {} event: {:?}", etype, e),
+                    self.scan_and_print(&mut e);
                 }
-            }
+                Err(e) => error!("failed to decode {} event: {:?}", etype, e),
+            },
 
             Type::FileUnlink => match event!(enc_event, bpf_events::UnlinkEvent) {
                 Ok(e) => {
@@ -2395,7 +2397,11 @@ impl Command {
                         Type::DnsQuery => scan_event!(p, DnsQueryData),
                         Type::SendData => scan_event!(p, SendDataData),
                         Type::InitModule => scan_event!(p, InitModuleData),
-                        Type::WriteConfig | Type::Write | Type::ReadConfig | Type::Read => {
+                        Type::WriteConfig
+                        | Type::Write
+                        | Type::ReadConfig
+                        | Type::Read
+                        | Type::WriteAndClose => {
                             scan_event!(p, FileData)
                         }
                         Type::FileUnlink => scan_event!(p, UnlinkData),

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -13,9 +13,9 @@ use gene::Engine;
 use kunai::containers::Container;
 use kunai::events::{
     BpfProgLoadData, BpfProgTypeInfo, BpfSocketFilterData, CloneData, ConnectData, DnsQueryData,
-    EventInfo, ExecveData, ExitData, FileRenameData, FileScanData, FilterInfo, InitModuleData,
-    KillData, KunaiEvent, MmapExecData, MprotectData, NetworkInfo, PrctlData, RWData, ScanResult,
-    SendDataData, SocketInfo, TargetTask, UnlinkData, UserEvent,
+    EventInfo, ExecveData, ExitData, FileData, FileRenameData, FileScanData, FilterInfo,
+    InitModuleData, KillData, KunaiEvent, MmapExecData, MprotectData, NetworkInfo, PrctlData,
+    ScanResult, SendDataData, SocketInfo, TargetTask, UnlinkData, UserEvent,
 };
 use kunai::info::{AdditionalInfo, StdEventInfo, TaskKey};
 use kunai::ioc::IoC;
@@ -852,14 +852,14 @@ impl<'s> EventConsumer<'s> {
     }
 
     #[inline]
-    fn rw_event(
+    fn file_event(
         &mut self,
         info: StdEventInfo,
-        event: &bpf_events::ConfigEvent,
-    ) -> UserEvent<RWData> {
+        event: &bpf_events::FileEvent,
+    ) -> UserEvent<FileData> {
         let (exe, command_line) = self.get_exe_and_command_line(&info);
 
-        let data = RWData {
+        let data = FileData {
             ancestors: self.get_ancestors_string(&info),
             command_line,
             exe: exe.into(),
@@ -1592,7 +1592,7 @@ impl<'s> EventConsumer<'s> {
             Type::WriteConfig | Type::Write | Type::ReadConfig | Type::Read => {
                 match event!(enc_event, bpf_events::ConfigEvent) {
                     Ok(e) => {
-                        let mut e = self.rw_event(std_info, e);
+                    let mut e = self.file_event(std_info, e);
                         self.scan_and_print(&mut e);
                     }
                     Err(e) => error!("failed to decode {} event: {:?}", etype, e),
@@ -2396,7 +2396,7 @@ impl Command {
                         Type::SendData => scan_event!(p, SendDataData),
                         Type::InitModule => scan_event!(p, InitModuleData),
                         Type::WriteConfig | Type::Write | Type::ReadConfig | Type::Read => {
-                            scan_event!(p, RWData)
+                            scan_event!(p, FileData)
                         }
                         Type::FileUnlink => scan_event!(p, UnlinkData),
                         Type::FileRename => scan_event!(p, FileRenameData),

--- a/kunai/src/config.rs
+++ b/kunai/src/config.rs
@@ -75,7 +75,10 @@ impl Default for Config {
         let mut events = vec![];
         for v in bpf_events::Type::variants() {
             // some events get disabled by default because there are too many
-            let en = !matches!(v, bpf_events::Type::Read | bpf_events::Type::Write);
+            let en = !matches!(
+                v,
+                bpf_events::Type::Read | bpf_events::Type::Write | bpf_events::Type::WriteAndClose
+            );
 
             if v.is_configurable() {
                 events.push(Event {

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -773,18 +773,18 @@ impl Scannable for InitModuleData {
 }
 
 def_user_data!(
-    pub struct RWData {
+    pub struct FileData {
         pub path: PathBuf,
     }
 );
 
-impl IocGetter for RWData {
+impl IocGetter for FileData {
     fn iocs(&mut self) -> Vec<Cow<'_, str>> {
         vec![self.exe.file.to_string_lossy(), self.path.to_string_lossy()]
     }
 }
 
-impl Scannable for RWData {
+impl Scannable for FileData {
     #[inline]
     fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
         vec![Cow::Borrowed(&self.exe.file), Cow::Borrowed(&self.path)]


### PR DESCRIPTION
This PR contains the changes needed to have a new event `write_and_close`

This event would be generated when a file gets closed after being written.
Motivation:
- `write` event is generated only when the file is first written
- `write` event is generated only once per task so if the file gets written once again (by the same task)
- such an event is a great trigger for file scanning as we are sure the file got closed (which is not the case of `write` event)

This PR also contains some little refactoring:
- renamed userland structures encoding file events
- bpf file tracking