### PR TITLE
feat: integrate community-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "communityid"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f129c597ee30e0dcb6745a5c6ac6b6ec97d2b5cfb16765a6510587d9da30bc"
+dependencies = [
+ "base64",
+ "serde",
+ "sha1",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1498,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "communityid",
  "env_logger",
  "firo",
  "fs-walk",

--- a/kunai-common/src/bpf_events/events/connect.rs
+++ b/kunai-common/src/bpf_events/events/connect.rs
@@ -1,11 +1,13 @@
-use crate::{bpf_events::Event, net::SockAddr};
+use crate::{
+    bpf_events::Event,
+    net::{SockAddr, SocketInfo},
+};
 
 pub type ConnectEvent = Event<ConnectData>;
 
 #[repr(C)]
 pub struct ConnectData {
-    pub family: u32,
-    pub proto: u16,
+    pub socket_info: SocketInfo,
     pub src: SockAddr,
     pub dst: SockAddr,
     pub connected: bool,

--- a/kunai-common/src/bpf_events/events/connect.rs
+++ b/kunai-common/src/bpf_events/events/connect.rs
@@ -5,6 +5,7 @@ pub type ConnectEvent = Event<ConnectData>;
 #[repr(C)]
 pub struct ConnectData {
     pub family: u32,
-    pub ip_port: SockAddr,
+    pub src: SockAddr,
+    pub dst: SockAddr,
     pub connected: bool,
 }

--- a/kunai-common/src/bpf_events/events/connect.rs
+++ b/kunai-common/src/bpf_events/events/connect.rs
@@ -1,10 +1,10 @@
-use crate::{bpf_events::Event, net::IpPort};
+use crate::{bpf_events::Event, net::SockAddr};
 
 pub type ConnectEvent = Event<ConnectData>;
 
 #[repr(C)]
 pub struct ConnectData {
     pub family: u32,
-    pub ip_port: IpPort,
+    pub ip_port: SockAddr,
     pub connected: bool,
 }

--- a/kunai-common/src/bpf_events/events/connect.rs
+++ b/kunai-common/src/bpf_events/events/connect.rs
@@ -7,7 +7,7 @@ pub type ConnectEvent = Event<ConnectData>;
 
 #[repr(C)]
 pub struct ConnectData {
-    pub socket_info: SocketInfo,
+    pub socket: SocketInfo,
     pub src: SockAddr,
     pub dst: SockAddr,
     pub connected: bool,

--- a/kunai-common/src/bpf_events/events/connect.rs
+++ b/kunai-common/src/bpf_events/events/connect.rs
@@ -5,6 +5,7 @@ pub type ConnectEvent = Event<ConnectData>;
 #[repr(C)]
 pub struct ConnectData {
     pub family: u32,
+    pub proto: u16,
     pub src: SockAddr,
     pub dst: SockAddr,
     pub connected: bool,

--- a/kunai-common/src/bpf_events/events/dns_query.rs
+++ b/kunai-common/src/bpf_events/events/dns_query.rs
@@ -28,9 +28,6 @@ impl DnsQueryData {
     pub fn header_is_null(&self) -> bool {
         let h = &self.packet_data()[..12];
         h.iter().filter(|&&b| b == 0).count() == 12
-        /*let part1: u64 = u64::from_be_bytes([h[7], h[6], h[5], h[4], h[3], h[2], h[1], h[0]]);
-        let part2: u32 = u32::from_be_bytes([h[11], h[10], h[9], h[8]]);
-        part2 == 0 && part1 == 0*/
     }
 
     pub fn packet_data(&self) -> &[u8] {

--- a/kunai-common/src/bpf_events/events/dns_query.rs
+++ b/kunai-common/src/bpf_events/events/dns_query.rs
@@ -1,5 +1,6 @@
 use crate::bpf_events::Event;
 use crate::macros::not_bpf_target_code;
+use crate::net::IpProto;
 use crate::{buffer::Buffer, net::SockAddr};
 
 pub const DNS_MAX_PACKET_SIZE: usize = 2048;
@@ -32,8 +33,8 @@ impl DnsQueryData {
     }
 
     pub fn packet_data(&self) -> &[u8] {
-        // this is a TCP connection SOCK_STREAM == 1
-        if self.proto == 1 && self.tcp_header && self.data.len() >= 14 {
+        // this is a TCP connection
+        if self.proto == IpProto::TCP as u16 && self.tcp_header && self.data.len() >= 14 {
             // there are two bytes at front encoding the size of the packet
             return &self.data.as_slice()[2..];
         }

--- a/kunai-common/src/bpf_events/events/dns_query.rs
+++ b/kunai-common/src/bpf_events/events/dns_query.rs
@@ -1,6 +1,6 @@
 use crate::bpf_events::Event;
 use crate::macros::not_bpf_target_code;
-use crate::{buffer::Buffer, net::IpPort};
+use crate::{buffer::Buffer, net::SockAddr};
 
 pub const DNS_MAX_PACKET_SIZE: usize = 2048;
 
@@ -15,7 +15,7 @@ pub enum DnsError {
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct DnsQueryData {
-    pub ip_port: IpPort,
+    pub ip_port: SockAddr,
     pub proto: u16,
     pub data: Buffer<DNS_MAX_PACKET_SIZE>,
     pub tcp_header: bool,

--- a/kunai-common/src/bpf_events/events/dns_query.rs
+++ b/kunai-common/src/bpf_events/events/dns_query.rs
@@ -15,7 +15,8 @@ pub enum DnsError {
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct DnsQueryData {
-    pub ip_port: SockAddr,
+    pub src: SockAddr,
+    pub dst: SockAddr,
     pub proto: u16,
     pub data: Buffer<DNS_MAX_PACKET_SIZE>,
     pub tcp_header: bool,

--- a/kunai-common/src/bpf_events/events/dns_query.rs
+++ b/kunai-common/src/bpf_events/events/dns_query.rs
@@ -1,6 +1,6 @@
 use crate::bpf_events::Event;
 use crate::macros::not_bpf_target_code;
-use crate::net::IpProto;
+use crate::net::{IpProto, SocketInfo};
 use crate::{buffer::Buffer, net::SockAddr};
 
 pub const DNS_MAX_PACKET_SIZE: usize = 2048;
@@ -16,9 +16,9 @@ pub enum DnsError {
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct DnsQueryData {
+    pub socket: SocketInfo,
     pub src: SockAddr,
     pub dst: SockAddr,
-    pub proto: u16,
     pub data: Buffer<DNS_MAX_PACKET_SIZE>,
     pub tcp_header: bool,
     pub error: DnsError,
@@ -34,7 +34,7 @@ impl DnsQueryData {
 
     pub fn packet_data(&self) -> &[u8] {
         // this is a TCP connection
-        if self.proto == IpProto::TCP as u16 && self.tcp_header && self.data.len() >= 14 {
+        if self.socket.proto == IpProto::TCP as u16 && self.tcp_header && self.data.len() >= 14 {
             // there are two bytes at front encoding the size of the packet
             return &self.data.as_slice()[2..];
         }

--- a/kunai-common/src/bpf_events/events/send_entropy.rs
+++ b/kunai-common/src/bpf_events/events/send_entropy.rs
@@ -6,6 +6,7 @@ pub const ENCRYPT_DATA_MAX_BUFFER_SIZE: usize = 4096;
 
 #[repr(C)]
 pub struct SendEntropyData {
+    pub proto: u16,
     pub src: SockAddr,
     pub dst: SockAddr,
     pub freq: [u32; 256],

--- a/kunai-common/src/bpf_events/events/send_entropy.rs
+++ b/kunai-common/src/bpf_events/events/send_entropy.rs
@@ -1,12 +1,12 @@
 use crate::{bpf_events::Event, macros::not_bpf_target_code};
 
-use crate::net::SockAddr;
+use crate::net::{SockAddr, SocketInfo};
 
 pub const ENCRYPT_DATA_MAX_BUFFER_SIZE: usize = 4096;
 
 #[repr(C)]
 pub struct SendEntropyData {
-    pub proto: u16,
+    pub socket: SocketInfo,
     pub src: SockAddr,
     pub dst: SockAddr,
     pub freq: [u32; 256],

--- a/kunai-common/src/bpf_events/events/send_entropy.rs
+++ b/kunai-common/src/bpf_events/events/send_entropy.rs
@@ -1,12 +1,13 @@
 use crate::{bpf_events::Event, macros::not_bpf_target_code};
 
-use crate::net::IpPort;
+use crate::net::SockAddr;
 
 pub const ENCRYPT_DATA_MAX_BUFFER_SIZE: usize = 4096;
 
 #[repr(C)]
 pub struct SendEntropyData {
-    pub ip_port: IpPort,
+    pub src: SockAddr,
+    pub dst: SockAddr,
     pub freq: [u32; 256],
     pub freq_sum: u32,
     pub real_data_size: u64,
@@ -28,8 +29,10 @@ impl SendEntropyEvent {
             self.data.freq_sum += 1;
         }
     }
+}
 
-    not_bpf_target_code! {
+not_bpf_target_code! {
+    impl SendEntropyEvent {
         // we cannot do complicated operations of f32 in eBPF
         #[inline]
         pub fn shannon_entropy(&self) -> f32{
@@ -46,4 +49,5 @@ impl SendEntropyEvent {
             entropy
         }
     }
+
 }

--- a/kunai-common/src/co_re/gen.rs
+++ b/kunai-common/src/co_re/gen.rs
@@ -1479,6 +1479,19 @@ pub struct sock {
     pub sk_type: __u16,
     pub sk_receive_queue: sk_buff_head,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sock___pre_5_6 {
+    pub sk_protocol: __u8,
+}
+extern "C" {
+    pub fn shim_sock___pre_5_6_sk_protocol(
+        sock___pre_5_6: *mut sock___pre_5_6,
+    ) -> ::core::ffi::c_uchar;
+}
+extern "C" {
+    pub fn shim_sock___pre_5_6_sk_protocol_exists(sock___pre_5_6: *mut sock___pre_5_6) -> bool;
+}
 extern "C" {
     pub fn shim_sock___sk_common(sock: *mut sock) -> *mut sock_common;
 }
@@ -1490,6 +1503,9 @@ extern "C" {
 }
 extern "C" {
     pub fn shim_sock_sk_protocol(sock: *mut sock) -> ::core::ffi::c_uchar;
+}
+extern "C" {
+    pub fn shim_sock_sk_protocol_user(sock: *mut sock) -> ::core::ffi::c_uchar;
 }
 extern "C" {
     pub fn shim_sock_sk_protocol_exists(sock: *mut sock) -> bool;

--- a/kunai-common/src/net.rs
+++ b/kunai-common/src/net.rs
@@ -210,77 +210,42 @@ impl SockType {
 #[derive(StrEnum, Debug, PartialEq, PartialOrd)]
 #[allow(non_camel_case_types)]
 pub enum IpProto {
-    #[str("ip")]
-    IP = 0, /* Dummy protocol for TCP		*/
-    #[str("icmp")]
-    ICMP = 1, /* Internet Control Message Protocol	*/
-    #[str("igmp")]
-    IGMP = 2, /* Internet Group Management Protocol	*/
-    #[str("ipip")]
-    IPIP = 4, /* IPIP tunnels (older KA9Q tunnels use 94) */
-    #[str("tcp")]
-    TCP = 6, /* Transmission Control Protocol	*/
-    #[str("egp")]
-    EGP = 8, /* Exterior Gateway Protocol		*/
-    #[str("pup")]
-    PUP = 12, /* PUP protocol				*/
-    #[str("udp")]
-    UDP = 17, /* User Datagram Protocol		*/
-    #[str("idp")]
-    IDP = 22, /* XNS IDP protocol			*/
-    #[str("tp")]
-    TP = 29, /* SO Transport Protocol Class 4	*/
-    #[str("dccp")]
-    DCCP = 33, /* Datagram Congestion Control Protocol */
-    #[str("ipv6")]
-    IPV6 = 41, /* IPv6-in-IPv4 tunnelling		*/
-    #[str("rsvp")]
-    RSVP = 46, /* RSVP Protocol			*/
-    #[str("gre")]
-    GRE = 47, /* Cisco GRE tunnels (rfc 1701,1702)	*/
-    #[str("esp")]
-    ESP = 50, /* Encapsulation Security Payload protocol */
-    #[str("ah")]
-    AH = 51, /* Authentication Header protocol	*/
-    #[str("mtp")]
-    MTP = 92, /* Multicast Transport Protocol		*/
-    #[str("beetph")]
-    BEETPH = 94, /* IP option pseudo header for BEET	*/
-    #[str("encap")]
-    ENCAP = 98, /* Encapsulation Header			*/
-    #[str("pim")]
-    PIM = 103, /* Protocol Independent Multicast	*/
-    #[str("comp")]
-    COMP = 108, /* Compression Header Protocol		*/
-    #[str("l2tp")]
-    L2TP = 115, /* Layer 2 Tunnelling Protocol		*/
-    #[str("sctp")]
-    SCTP = 132, /* Stream Control Transport Protocol	*/
-    #[str("udplite")]
-    UDPLITE = 136, /* UDP-Lite (RFC 3828)			*/
-    #[str("mpls")]
-    MPLS = 137, /* MPLS in IP (RFC 4023)		*/
-    #[str("ethernet")]
+    IP = 0,         /* Dummy protocol for TCP		*/
+    ICMP = 1,       /* Internet Control Message Protocol	*/
+    IGMP = 2,       /* Internet Group Management Protocol	*/
+    IPIP = 4,       /* IPIP tunnels (older KA9Q tunnels use 94) */
+    TCP = 6,        /* Transmission Control Protocol	*/
+    EGP = 8,        /* Exterior Gateway Protocol		*/
+    PUP = 12,       /* PUP protocol				*/
+    UDP = 17,       /* User Datagram Protocol		*/
+    IDP = 22,       /* XNS IDP protocol			*/
+    TP = 29,        /* SO Transport Protocol Class 4	*/
+    DCCP = 33,      /* Datagram Congestion Control Protocol */
+    IPV6 = 41,      /* IPv6-in-IPv4 tunnelling		*/
+    RSVP = 46,      /* RSVP Protocol			*/
+    GRE = 47,       /* Cisco GRE tunnels (rfc 1701,1702)	*/
+    ESP = 50,       /* Encapsulation Security Payload protocol */
+    AH = 51,        /* Authentication Header protocol	*/
+    MTP = 92,       /* Multicast Transport Protocol		*/
+    BEETPH = 94,    /* IP option pseudo header for BEET	*/
+    ENCAP = 98,     /* Encapsulation Header			*/
+    PIM = 103,      /* Protocol Independent Multicast	*/
+    COMP = 108,     /* Compression Header Protocol		*/
+    L2TP = 115,     /* Layer 2 Tunnelling Protocol		*/
+    SCTP = 132,     /* Stream Control Transport Protocol	*/
+    UDPLITE = 136,  /* UDP-Lite (RFC 3828)			*/
+    MPLS = 137,     /* MPLS in IP (RFC 4023)		*/
     ETHERNET = 143, /* Ethernet-within-IPv6 Encapsulation	*/
-    #[str("raw")]
-    RAW = 255, /* Raw IP packets			*/
-    #[str("smc")]
-    SMC = 256, /* Shared Memory Communications		*/
-    #[str("mptcp")]
-    MPTCP = 262, /* Multipath TCP connection		*/
+    RAW = 255,      /* Raw IP packets			*/
+    SMC = 256,      /* Shared Memory Communications		*/
+    MPTCP = 262,    /* Multipath TCP connection		*/
     // IPv6 related
-    #[str("routing")]
-    ROUTING = 43, /* IPv6 routing header		*/
-    #[str("fragment")]
+    ROUTING = 43,  /* IPv6 routing header		*/
     FRAGMENT = 44, /* IPv6 fragmentation header	*/
-    #[str("icmpv6")]
-    ICMPV6 = 58, /* ICMPv6			*/
-    #[str("none")]
-    NONE = 59, /* IPv6 no next header		*/
-    #[str("dstopts")]
-    DSTOPTS = 60, /* IPv6 destination options	*/
-    #[str("mh")]
-    MH = 135, /* IPv6 mobility header		*/
+    ICMPV6 = 58,   /* ICMPv6			*/
+    NONE = 59,     /* IPv6 no next header		*/
+    DSTOPTS = 60,  /* IPv6 destination options	*/
+    MH = 135,      /* IPv6 mobility header		*/
 }
 
 #[repr(C)]
@@ -290,6 +255,8 @@ pub struct SocketInfo {
     pub domain: u16,
     /// Must be [SockType] value
     pub ty: u16,
+    /// Value of socket.sk_protocol
+    pub proto: u16,
 }
 
 impl SocketInfo {

--- a/kunai-common/src/net.rs
+++ b/kunai-common/src/net.rs
@@ -200,6 +200,89 @@ impl SockType {
     }
 }
 
+// IPPROTO_ macros defined in the Linux kernel
+// even though some IPPROTO_ are u16 those can
+// be casted to their u8 counterpart probably
+// because in IP header the protocol is u8
+// https://elixir.bootlin.com/linux/v6.11/source/include/uapi/linux/in.h#L29
+// https://elixir.bootlin.com/linux/v6.11/source/include/uapi/linux/in6.h#L132
+#[repr(u16)]
+#[derive(StrEnum, Debug, PartialEq, PartialOrd)]
+#[allow(non_camel_case_types)]
+pub enum IpProto {
+    #[str("ip")]
+    IP = 0, /* Dummy protocol for TCP		*/
+    #[str("icmp")]
+    ICMP = 1, /* Internet Control Message Protocol	*/
+    #[str("igmp")]
+    IGMP = 2, /* Internet Group Management Protocol	*/
+    #[str("ipip")]
+    IPIP = 4, /* IPIP tunnels (older KA9Q tunnels use 94) */
+    #[str("tcp")]
+    TCP = 6, /* Transmission Control Protocol	*/
+    #[str("egp")]
+    EGP = 8, /* Exterior Gateway Protocol		*/
+    #[str("pup")]
+    PUP = 12, /* PUP protocol				*/
+    #[str("udp")]
+    UDP = 17, /* User Datagram Protocol		*/
+    #[str("idp")]
+    IDP = 22, /* XNS IDP protocol			*/
+    #[str("tp")]
+    TP = 29, /* SO Transport Protocol Class 4	*/
+    #[str("dccp")]
+    DCCP = 33, /* Datagram Congestion Control Protocol */
+    #[str("ipv6")]
+    IPV6 = 41, /* IPv6-in-IPv4 tunnelling		*/
+    #[str("rsvp")]
+    RSVP = 46, /* RSVP Protocol			*/
+    #[str("gre")]
+    GRE = 47, /* Cisco GRE tunnels (rfc 1701,1702)	*/
+    #[str("esp")]
+    ESP = 50, /* Encapsulation Security Payload protocol */
+    #[str("ah")]
+    AH = 51, /* Authentication Header protocol	*/
+    #[str("mtp")]
+    MTP = 92, /* Multicast Transport Protocol		*/
+    #[str("beetph")]
+    BEETPH = 94, /* IP option pseudo header for BEET	*/
+    #[str("encap")]
+    ENCAP = 98, /* Encapsulation Header			*/
+    #[str("pim")]
+    PIM = 103, /* Protocol Independent Multicast	*/
+    #[str("comp")]
+    COMP = 108, /* Compression Header Protocol		*/
+    #[str("l2tp")]
+    L2TP = 115, /* Layer 2 Tunnelling Protocol		*/
+    #[str("sctp")]
+    SCTP = 132, /* Stream Control Transport Protocol	*/
+    #[str("udplite")]
+    UDPLITE = 136, /* UDP-Lite (RFC 3828)			*/
+    #[str("mpls")]
+    MPLS = 137, /* MPLS in IP (RFC 4023)		*/
+    #[str("ethernet")]
+    ETHERNET = 143, /* Ethernet-within-IPv6 Encapsulation	*/
+    #[str("raw")]
+    RAW = 255, /* Raw IP packets			*/
+    #[str("smc")]
+    SMC = 256, /* Shared Memory Communications		*/
+    #[str("mptcp")]
+    MPTCP = 262, /* Multipath TCP connection		*/
+    // IPv6 related
+    #[str("routing")]
+    ROUTING = 43, /* IPv6 routing header		*/
+    #[str("fragment")]
+    FRAGMENT = 44, /* IPv6 fragmentation header	*/
+    #[str("icmpv6")]
+    ICMPV6 = 58, /* ICMPv6			*/
+    #[str("none")]
+    NONE = 59, /* IPv6 no next header		*/
+    #[str("dstopts")]
+    DSTOPTS = 60, /* IPv6 destination options	*/
+    #[str("mh")]
+    MH = 135, /* IPv6 mobility header		*/
+}
+
 #[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct SocketInfo {

--- a/kunai-common/src/net.rs
+++ b/kunai-common/src/net.rs
@@ -54,13 +54,13 @@ pub enum IpType {
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct IpPort {
+pub struct SockAddr {
     pub ty: IpType,
     data: [u32; 4],
     port: u16,
 }
 
-impl Default for IpPort {
+impl Default for SockAddr {
     fn default() -> Self {
         Self {
             ty: IpType::V4,
@@ -70,9 +70,9 @@ impl Default for IpPort {
     }
 }
 
-impl IpPort {
+impl SockAddr {
     pub fn new_v4_from_be(addr: u32, port: u16) -> Self {
-        IpPort {
+        SockAddr {
             ty: IpType::V4,
             data: [addr, 0, 0, 0],
             port,
@@ -80,7 +80,7 @@ impl IpPort {
     }
 
     pub fn new_v6_from_be(addr: [u32; 4], port: u16) -> Self {
-        IpPort {
+        SockAddr {
             ty: IpType::V6,
             data: addr,
             port,

--- a/kunai-common/src/net/bpf.rs
+++ b/kunai-common/src/net/bpf.rs
@@ -5,9 +5,9 @@ use crate::co_re::sockaddr_in;
 use crate::co_re::sockaddr_in6;
 use crate::consts::*;
 
-use super::{Error, IpPort, SocketInfo};
+use super::{Error, SockAddr, SocketInfo};
 
-impl IpPort {
+impl SockAddr {
     #[inline(always)]
     pub unsafe fn from_sockaddr(sa: sockaddr) -> Result<Self, Error> {
         let sa_family = sa.sa_family().ok_or(Error::SaFamilyMissing)?;
@@ -18,7 +18,7 @@ impl IpPort {
             let addr = sa_in.s_addr().ok_or(Error::SaInAddrMissing)?.to_be();
             let port = sa_in.sin_port().ok_or(Error::SaInPortMissing)?.to_be();
 
-            return Ok(IpPort::new_v4_from_be(addr, port));
+            return Ok(SockAddr::new_v4_from_be(addr, port));
         } else if sa_family == AF_INET6 {
             let sa_in6 = sockaddr_in6::from(sa);
 
@@ -28,7 +28,7 @@ impl IpPort {
                 .ok_or(Error::SaIn6AddrMissing)?;
             let port = sa_in6.sin6_port().ok_or(Error::SaIn6PortMissing)?.to_be();
 
-            return Ok(IpPort::new_v6_from_be(addr, port));
+            return Ok(SockAddr::new_v6_from_be(addr, port));
         }
 
         return Err(Error::UnsupportedSaFamily);
@@ -40,12 +40,12 @@ impl IpPort {
         let dport = sk.skc_dport().ok_or(Error::SkcPortPairMissing)?.to_be();
 
         if sa_family == AF_INET as u16 {
-            return Ok(IpPort::new_v4_from_be(
+            return Ok(SockAddr::new_v4_from_be(
                 sk.skc_daddr().ok_or(Error::SkcAddrPairMissing)?.to_be(),
                 dport,
             ));
         } else if sa_family == AF_INET6 as u16 {
-            return Ok(IpPort::new_v6_from_be(
+            return Ok(SockAddr::new_v6_from_be(
                 sk.skc_v6_daddr()
                     .and_then(|in6| in6.addr32())
                     .ok_or(Error::SkcV6daddrMissing)?,
@@ -65,14 +65,14 @@ impl IpPort {
             .ok_or(Error::SkcPortPairMissing)?;
 
         if sa_family == AF_INET as u16 {
-            return Ok(IpPort::new_v4_from_be(
+            return Ok(SockAddr::new_v4_from_be(
                 sk.skc_rcv_saddr()
                     .map(u32::to_be)
                     .ok_or(Error::SkcAddrPairMissing)?,
                 sport,
             ));
         } else if sa_family == AF_INET6 as u16 {
-            return Ok(IpPort::new_v6_from_be(
+            return Ok(SockAddr::new_v6_from_be(
                 sk.skc_v6_rcv_saddr()
                     .and_then(|in6| in6.addr32())
                     .ok_or(Error::SkcV6daddrMissing)?,

--- a/kunai-common/src/net/bpf.rs
+++ b/kunai-common/src/net/bpf.rs
@@ -93,7 +93,8 @@ impl TryFrom<crate::co_re::sock> for SocketInfo {
             let ty = core_read_kernel!(s, sk_type).ok_or(Error::SkTypeMissing)?;
             let domain =
                 core_read_kernel!(s, sk_common, skc_family).ok_or(Error::SkcFamilyMissing)?;
-            Ok(Self { domain, ty })
+            let proto = core_read_kernel!(s, sk_protocol).ok_or(Error::SkProtocolMissing)?;
+            Ok(Self { domain, ty, proto })
         }
     }
 }

--- a/kunai-common/src/net/user.rs
+++ b/kunai-common/src/net/user.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use super::{IpType, SaFamily, SockAddr, SockType, SocketInfo};
+use super::{IpProto, IpType, SaFamily, SockAddr, SockType, SocketInfo};
 
 impl From<SockAddr> for IpAddr {
     fn from(value: SockAddr) -> Self {
@@ -27,6 +27,14 @@ impl SocketInfo {
             t.as_str().into()
         } else {
             format!("unknown({})", self.domain)
+        }
+    }
+
+    pub fn proto_to_string(&self) -> String {
+        if let Ok(p) = IpProto::try_from_uint(self.proto) {
+            p.as_str().into()
+        } else {
+            format!("unknown({})", self.proto)
         }
     }
 }

--- a/kunai-common/src/net/user.rs
+++ b/kunai-common/src/net/user.rs
@@ -1,9 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use super::{IpPort, IpType, SaFamily, SockType, SocketInfo};
+use super::{IpType, SaFamily, SockAddr, SockType, SocketInfo};
 
-impl From<IpPort> for IpAddr {
-    fn from(value: IpPort) -> Self {
+impl From<SockAddr> for IpAddr {
+    fn from(value: SockAddr) -> Self {
         match value.ty {
             IpType::V4 => IpAddr::V4(Ipv4Addr::from(value.data[0])),
             IpType::V6 => IpAddr::V6(Ipv6Addr::from(value.ip())),

--- a/kunai-ebpf/src/probes/connect.rs
+++ b/kunai-ebpf/src/probes/connect.rs
@@ -85,7 +85,7 @@ unsafe fn try_exit_connect(
     // retrieve sock_common to grap src information
     let sk_common = core_read_kernel!(sk, sk_common)?;
 
-    event.data.socket_info = SocketInfo::try_from(sk)?;
+    event.data.socket = SocketInfo::try_from(sk)?;
     event.data.src = SockAddr::src_from_sock_common(sk_common)?;
     event.data.dst = dst;
     event.data.connected = rc == 0 || rc == -EINPROGRESS;

--- a/kunai-ebpf/src/probes/connect.rs
+++ b/kunai-ebpf/src/probes/connect.rs
@@ -80,13 +80,12 @@ unsafe fn try_exit_connect(
         _ => return Ok(()),
     };
 
+    let socket = co_re::socket::from_ptr(core_read_kernel!(file, private_data)? as *const _);
     // retrieve sock_common to grap src information
-    let sk_common = {
-        let socket = co_re::socket::from_ptr(core_read_kernel!(file, private_data)? as *const _);
-        core_read_kernel!(socket, sk, sk_common)?
-    };
+    let sk_common = core_read_kernel!(socket, sk, sk_common)?;
 
     event.data.family = sa_family;
+    event.data.proto = core_read_kernel!(socket, sk, sk_protocol)?;
     event.data.src = SockAddr::src_from_sock_common(sk_common)?;
     event.data.dst = dst;
     event.data.connected = rc == 0 || rc == -EINPROGRESS;

--- a/kunai-ebpf/src/probes/connect.rs
+++ b/kunai-ebpf/src/probes/connect.rs
@@ -3,7 +3,7 @@ use super::*;
 use aya_ebpf::programs::ProbeContext;
 use kunai_common::{
     kprobe::{KProbeEntryContext, ProbeFn},
-    net::IpPort,
+    net::SockAddr,
 };
 
 #[kprobe(function = "__sys_connect")]
@@ -53,7 +53,7 @@ unsafe fn try_exit_connect(
             let ip = core_read_user!(in_addr, s_addr)?.to_be();
             let port = core_read_user!(in_addr, sin_port)?.to_be();
 
-            IpPort::new_v4_from_be(ip, port)
+            SockAddr::new_v4_from_be(ip, port)
         }
         AF_INET6 => {
             let in6_addr: co_re::sockaddr_in6 = addr.into();
@@ -61,7 +61,7 @@ unsafe fn try_exit_connect(
             let port = core_read_user!(in6_addr, sin6_port)?.to_be();
             // in theory we don't need to reverse addr for ipv6 as we read
             // data which is already big endian
-            IpPort::new_v6_from_be(core_read_user!(ip, addr32)?, port)
+            SockAddr::new_v6_from_be(core_read_user!(ip, addr32)?, port)
         }
         _ => return Ok(()),
     };

--- a/kunai-ebpf/src/probes/dns.rs
+++ b/kunai-ebpf/src/probes/dns.rs
@@ -62,7 +62,8 @@ impl SockHelper {
         alloc::init()?;
         let event = alloc::alloc_zero::<DnsQueryEvent>()?;
 
-        event.data.ip_port = dst;
+        event.data.src = SockAddr::src_from_sock_common(sk_common)?;
+        event.data.dst = dst;
         event.data.proto = sk_type;
         event.data.tcp_header = tcp_header;
 

--- a/kunai-ebpf/src/probes/dns.rs
+++ b/kunai-ebpf/src/probes/dns.rs
@@ -39,7 +39,7 @@ impl SockHelper {
         let socket = self.socket;
         let sock = core_read_kernel!(socket, sk)?;
         let sk_common = core_read_kernel!(sock, sk_common)?;
-        let sk_type = core_read_kernel!(sock, sk_type)?;
+        let sk_protocol = core_read_kernel!(sock, sk_protocol)?;
 
         let sa_family = core_read_kernel!(sk_common, skc_family)?;
 
@@ -64,7 +64,7 @@ impl SockHelper {
 
         event.data.src = SockAddr::src_from_sock_common(sk_common)?;
         event.data.dst = dst;
-        event.data.proto = sk_type;
+        event.data.proto = sk_protocol;
         event.data.tcp_header = tcp_header;
 
         match self.udata {

--- a/kunai-ebpf/src/probes/dns.rs
+++ b/kunai-ebpf/src/probes/dns.rs
@@ -62,7 +62,6 @@ impl SockHelper {
         alloc::init()?;
         let event = alloc::alloc_zero::<DnsQueryEvent>()?;
 
-        //event.info.timestamp = event_ts;
         event.data.ip_port = ip_port;
         event.data.proto = sk_type;
         event.data.tcp_header = tcp_header;

--- a/kunai-ebpf/src/probes/send_data.rs
+++ b/kunai-ebpf/src/probes/send_data.rs
@@ -1,6 +1,9 @@
 use super::*;
 use aya_ebpf::programs::ProbeContext;
-use kunai_common::{buffer::Buffer, net::SockAddr};
+use kunai_common::{
+    buffer::Buffer,
+    net::{SockAddr, SocketInfo},
+};
 
 /*
 Experimental probe to detect encrypted trafic based
@@ -82,7 +85,7 @@ unsafe fn try_sock_send_data(ctx: &ProbeContext) -> ProbeResult<()> {
     event.init_from_current_task(Type::SendData)?;
 
     // setting events' data
-    event.data.proto = core_read_kernel!(sock, sk_protocol)?;
+    event.data.socket = SocketInfo::try_from(sock)?;
     event.data.src = src_ip_port;
     event.data.dst = dst_ip_port;
     event.data.real_data_size = msg_size;

--- a/kunai-ebpf/src/probes/send_data.rs
+++ b/kunai-ebpf/src/probes/send_data.rs
@@ -44,6 +44,8 @@ unsafe fn try_sock_send_data(ctx: &ProbeContext) -> ProbeResult<()> {
 
     let iov_iter = core_read_kernel!(pmsg, msg_iter)?;
 
+    alloc::init()?;
+
     let iov_buf = alloc::alloc_zero::<Buffer<ENCRYPT_DATA_MAX_BUFFER_SIZE>>()?;
 
     let msg_size = core_read_kernel!(iov_iter, count)?;

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -59,6 +59,7 @@ huby = { version = "0.1", features = ["serde"] }
 firo = { version = "0.1" }
 yara-x = { version = "0.8.0" }
 fs-walk = { version = "0.1.0" }
+communityid = { version = "0.1", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.12.0"

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -812,11 +812,11 @@ impl<'s> EventConsumer<'s> {
 
         let src: SockAddr = event.data.src.into();
         let dst: SockAddr = event.data.dst.into();
-        let proto = ip_proto_to_string(event.data.proto);
+        let si = SocketInfo::from(event.data.socket);
 
         let community_id = Flow::new(
             // this is valid to cast as a u8
-            Protocol::from(event.data.proto as u8),
+            Protocol::from(event.data.socket.proto as u8),
             src.ip,
             src.port,
             dst.ip,
@@ -834,7 +834,7 @@ impl<'s> EventConsumer<'s> {
             data.command_line = command_line.clone();
             data.exe = exe.clone().into();
             data.query = r.question.clone();
-            data.proto = proto.clone();
+            data.socket = si.clone();
             data.src = src;
             data.dns_server = NetworkInfo {
                 hostname: None,

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1035,7 +1035,7 @@ impl<'s> EventConsumer<'s> {
         let src: SockAddr = event.data.src.into();
 
         let flow = Flow::new(
-            Protocol::from(event.data.proto as u8),
+            Protocol::from(event.data.socket.proto as u8),
             src.ip,
             src.port,
             dst.ip,
@@ -1046,7 +1046,7 @@ impl<'s> EventConsumer<'s> {
             ancestors: self.get_ancestors_string(&info),
             exe: exe.into(),
             command_line,
-            proto: ip_proto_to_string(event.data.proto),
+            socket: SocketInfo::from(event.data.socket),
             src: event.data.src.into(),
             dst: NetworkInfo {
                 hostname: Some(self.get_resolved(dst.ip, &info).into()),

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1014,16 +1014,10 @@ impl<'s> EventConsumer<'s> {
         event: &bpf_events::SendEntropyEvent,
     ) -> UserEvent<SendDataData> {
         let (exe, command_line) = self.get_exe_and_command_line(&info);
-        let dst_ip: IpAddr = event.data.dst.into();
-        let src_ip: IpAddr = event.data.src.into();
+        let dst: SockAddr = event.data.dst.into();
+        let src: SockAddr = event.data.src.into();
 
-        let flow = Flow::new(
-            Protocol::TCP,
-            src_ip,
-            event.data.src.port(),
-            dst_ip,
-            event.data.dst.port(),
-        );
+        let flow = Flow::new(Protocol::TCP, src.ip, src.port, dst.ip, dst.port);
 
         let data = SendDataData {
             ancestors: self.get_ancestors_string(&info),
@@ -1031,11 +1025,11 @@ impl<'s> EventConsumer<'s> {
             command_line,
             src: event.data.src.into(),
             dst: NetworkInfo {
-                hostname: Some(self.get_resolved(dst_ip, &info).into()),
-                ip: dst_ip,
-                port: event.data.dst.port(),
-                public: is_public_ip(dst_ip),
-                is_v6: event.data.dst.is_v6(),
+                hostname: Some(self.get_resolved(dst.ip, &info).into()),
+                ip: dst.ip,
+                port: dst.port,
+                public: is_public_ip(dst.ip),
+                is_v6: dst.ip.is_ipv6(),
             },
             community_id: flow.community_id_v1(0).base64(),
             data_entropy: event.shannon_entropy(),

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -997,7 +997,7 @@ impl<'s> EventConsumer<'s> {
         let dst: SockAddr = event.data.dst.into();
 
         let flow: Flow = Flow::new(
-            Protocol::from(event.data.socket_info.proto as u8),
+            Protocol::from(event.data.socket.proto as u8),
             src.ip,
             src.port,
             dst.ip,
@@ -1008,7 +1008,7 @@ impl<'s> EventConsumer<'s> {
             ancestors: self.get_ancestors_string(&info),
             command_line,
             exe: exe.into(),
-            socket: SocketInfo::from(event.data.socket_info),
+            socket: SocketInfo::from(event.data.socket),
             src,
             dst: NetworkInfo {
                 hostname: Some(self.get_resolved(dst.ip, &info).into()),

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -29,7 +29,6 @@ use kunai_common::bpf_events::{
     MAX_BPF_EVENT_SIZE,
 };
 use kunai_common::config::{BpfConfig, Filter};
-use kunai_common::net::IpProto;
 use kunai_common::{inspect_err, kernel};
 
 use kunai_common::version::KernelVersion;
@@ -813,12 +812,7 @@ impl<'s> EventConsumer<'s> {
 
         let src: SockAddr = event.data.src.into();
         let dst: SockAddr = event.data.dst.into();
-
-        let ip_proto = IpProto::try_from_uint(event.data.proto).ok();
-
-        let proto: String = ip_proto
-            .map(|p| p.as_str().into())
-            .unwrap_or(format!("unknown({})", event.data.proto));
+        let proto = ip_proto_to_string(event.data.proto);
 
         let community_id = Flow::new(
             // this is valid to cast as a u8

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1037,12 +1037,19 @@ impl<'s> EventConsumer<'s> {
         let dst: SockAddr = event.data.dst.into();
         let src: SockAddr = event.data.src.into();
 
-        let flow = Flow::new(Protocol::TCP, src.ip, src.port, dst.ip, dst.port);
+        let flow = Flow::new(
+            Protocol::from(event.data.proto as u8),
+            src.ip,
+            src.port,
+            dst.ip,
+            dst.port,
+        );
 
         let data = SendDataData {
             ancestors: self.get_ancestors_string(&info),
             exe: exe.into(),
             command_line,
+            proto: ip_proto_to_string(event.data.proto),
             src: event.data.src.into(),
             dst: NetworkInfo {
                 hostname: Some(self.get_resolved(dst.ip, &info).into()),

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -951,10 +951,7 @@ impl<'s> EventConsumer<'s> {
             ancestors: self.get_ancestors_string(&info),
             command_line,
             exe: exe.into(),
-            socket: SocketInfo {
-                domain: event.data.socket_info.domain_to_string(),
-                ty: event.data.socket_info.type_to_string(),
-            },
+            socket: SocketInfo::from(event.data.socket_info),
             filter: FilterInfo {
                 md5: md5_data(event.data.filter.as_slice()),
                 sha1: sha1_data(event.data.filter.as_slice()),
@@ -1000,7 +997,7 @@ impl<'s> EventConsumer<'s> {
         let dst: SockAddr = event.data.dst.into();
 
         let flow: Flow = Flow::new(
-            Protocol::from(event.data.proto as u8),
+            Protocol::from(event.data.socket_info.proto as u8),
             src.ip,
             src.port,
             dst.ip,
@@ -1011,7 +1008,7 @@ impl<'s> EventConsumer<'s> {
             ancestors: self.get_ancestors_string(&info),
             command_line,
             exe: exe.into(),
-            proto: ip_proto_to_string(event.data.proto),
+            socket: SocketInfo::from(event.data.socket_info),
             src,
             dst: NetworkInfo {
                 hostname: Some(self.get_resolved(dst.ip, &info).into()),

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -999,12 +999,19 @@ impl<'s> EventConsumer<'s> {
         let src: SockAddr = event.data.src.into();
         let dst: SockAddr = event.data.dst.into();
 
-        let flow: Flow = Flow::new(Protocol::TCP, src.ip, src.port, dst.ip, dst.port);
+        let flow: Flow = Flow::new(
+            Protocol::from(event.data.proto as u8),
+            src.ip,
+            src.port,
+            dst.ip,
+            dst.port,
+        );
 
         let data = ConnectData {
             ancestors: self.get_ancestors_string(&info),
             command_line,
             exe: exe.into(),
+            proto: ip_proto_to_string(event.data.proto),
             src,
             dst: NetworkInfo {
                 hostname: Some(self.get_resolved(dst.ip, &info).into()),

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -756,7 +756,7 @@ impl IocGetter for DnsQueryData {
 
 def_user_data!(
     pub struct SendDataData {
-        pub proto: String,
+        pub socket: SocketInfo,
         pub src: SockAddr,
         pub dst: NetworkInfo,
         pub community_id: String,

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -661,6 +661,7 @@ impl IocGetter for NetworkInfo {
 
 def_user_data!(
     pub struct ConnectData {
+        pub proto: String,
         pub src: SockAddr,
         pub dst: NetworkInfo,
         pub community_id: String,

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -756,6 +756,7 @@ impl IocGetter for DnsQueryData {
 
 def_user_data!(
     pub struct SendDataData {
+        pub proto: String,
         pub src: SockAddr,
         pub dst: NetworkInfo,
         pub community_id: String,

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -685,9 +685,9 @@ impl IocGetter for ConnectData {
 def_user_data!(
     #[derive(Default)]
     pub struct DnsQueryData {
+        pub socket: SocketInfo,
         pub src: SockAddr,
         pub query: String,
-        pub proto: String,
         pub response: String,
         pub dns_server: NetworkInfo,
         pub community_id: String,
@@ -915,7 +915,7 @@ impl Scannable for BpfProgLoadData {
     }
 }
 
-#[derive(Debug, FieldGetter, Serialize, Deserialize)]
+#[derive(Default, Debug, FieldGetter, Serialize, Deserialize, Clone)]
 pub struct SocketInfo {
     pub domain: String,
     #[serde(rename = "type")]

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -602,6 +602,21 @@ impl Scannable for MprotectData {
 impl_std_iocs!(MprotectData);
 
 #[derive(Debug, Serialize, Deserialize, FieldGetter)]
+pub struct SockAddr {
+    pub ip: IpAddr,
+    pub port: u16,
+}
+
+impl From<kunai_common::net::SockAddr> for SockAddr {
+    fn from(value: kunai_common::net::SockAddr) -> Self {
+        Self {
+            ip: IpAddr::from(value),
+            port: value.port(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, FieldGetter)]
 pub struct NetworkInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
@@ -727,7 +742,9 @@ impl IocGetter for DnsQueryData {
 
 def_user_data!(
     pub struct SendDataData {
+        pub src: SockAddr,
         pub dst: NetworkInfo,
+        pub community_id: String,
         pub data_entropy: f32,
         pub data_size: u64,
     }

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, FixedOffset, SecondsFormat, Utc};
 use gene::{Event, FieldGetter, FieldValue};
 use gene_derive::{Event, FieldGetter};
 
-use kunai_common::bpf_events;
+use kunai_common::{bpf_events, net};
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
@@ -661,7 +661,7 @@ impl IocGetter for NetworkInfo {
 
 def_user_data!(
     pub struct ConnectData {
-        pub proto: String,
+        pub socket: SocketInfo,
         pub src: SockAddr,
         pub dst: NetworkInfo,
         pub community_id: String,
@@ -920,6 +920,17 @@ pub struct SocketInfo {
     pub domain: String,
     #[serde(rename = "type")]
     pub ty: String,
+    pub proto: String,
+}
+
+impl From<net::SocketInfo> for SocketInfo {
+    fn from(value: net::SocketInfo) -> Self {
+        Self {
+            domain: value.domain_to_string(),
+            ty: value.type_to_string(),
+            proto: value.proto_to_string(),
+        }
+    }
 }
 
 #[derive(Debug, FieldGetter, Serialize, Deserialize)]

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -601,10 +601,19 @@ impl Scannable for MprotectData {
 
 impl_std_iocs!(MprotectData);
 
-#[derive(Debug, Serialize, Deserialize, FieldGetter)]
+#[derive(Debug, Serialize, Deserialize, FieldGetter, Clone, Copy)]
 pub struct SockAddr {
     pub ip: IpAddr,
     pub port: u16,
+}
+
+impl Default for SockAddr {
+    fn default() -> Self {
+        Self {
+            ip: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            port: 0,
+        }
+    }
 }
 
 impl From<kunai_common::net::SockAddr> for SockAddr {
@@ -675,10 +684,12 @@ impl IocGetter for ConnectData {
 def_user_data!(
     #[derive(Default)]
     pub struct DnsQueryData {
+        pub src: SockAddr,
         pub query: String,
         pub proto: String,
         pub response: String,
         pub dns_server: NetworkInfo,
+        pub community_id: String,
         #[serde(skip)]
         #[getter(skip)]
         responses: Vec<String>,

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -652,7 +652,9 @@ impl IocGetter for NetworkInfo {
 
 def_user_data!(
     pub struct ConnectData {
+        pub src: SockAddr,
         pub dst: NetworkInfo,
+        pub community_id: String,
         pub connected: bool,
     }
 );

--- a/kunai/src/util.rs
+++ b/kunai/src/util.rs
@@ -1,6 +1,5 @@
 use core::mem::{size_of, MaybeUninit};
 use ip_network::IpNetwork;
-use kunai_common::net::IpProto;
 use md5::{Digest, Md5};
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
@@ -20,15 +19,6 @@ pub fn is_public_ip(ip: IpAddr) -> bool {
         IpNetwork::V4(v4) => !v4.is_private(),
         IpNetwork::V6(v6) => !v6.is_unique_local(),
     }
-}
-
-/// helper function to convert a u16 [IpProto] to string
-#[inline(always)]
-pub fn ip_proto_to_string(i: u16) -> String {
-    IpProto::try_from_uint(i)
-        .ok()
-        .map(|p| p.as_str().into())
-        .unwrap_or(format!("unknown({})", i))
 }
 
 fn sysconf<T: From<i64>>(var: libc::c_int) -> Result<T, io::Error> {

--- a/kunai/src/util.rs
+++ b/kunai/src/util.rs
@@ -1,5 +1,6 @@
 use core::mem::{size_of, MaybeUninit};
 use ip_network::IpNetwork;
+use kunai_common::net::IpProto;
 use md5::{Digest, Md5};
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
@@ -19,6 +20,15 @@ pub fn is_public_ip(ip: IpAddr) -> bool {
         IpNetwork::V4(v4) => !v4.is_private(),
         IpNetwork::V6(v6) => !v6.is_unique_local(),
     }
+}
+
+/// helper function to convert a u16 [IpProto] to string
+#[inline(always)]
+pub fn ip_proto_to_string(i: u16) -> String {
+    IpProto::try_from_uint(i)
+        .ok()
+        .map(|p| p.as_str().into())
+        .unwrap_or(format!("unknown({})", i))
 }
 
 fn sysconf<T: From<i64>>(var: libc::c_int) -> Result<T, io::Error> {


### PR DESCRIPTION
This PR aims at integrating community-id ( https://github.com/corelight/community-id-spec) into some of the kunai logs:

This feature is valuable on the following aspects:
- it allows to correlate kunai log with external log/alert sources such as IDS or traffic analysis tools
- given a community-id from an external source and thanks to the task UUIDs used in kunai it is possible to find the exact root (application, parents and all ancestors) of such traffic.

Fields of applications:
- Incident Response
- Threat-Hunting
- Network alert investigation
- Understand which application generate which traffic

Limitations:
- NAT traffic (often used in Linux containers) won't produce community-id that can be correlated with traffic analysis tools
