### PR TITLE
feat: filter by event name in rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "procfs",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha1",
  "sha2",
  "tempfile",

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -59,6 +59,7 @@ firo = { version = "0.1" }
 yara-x = { version = "0.8.0" }
 fs-walk = { version = "0.1.0" }
 communityid = { version = "0.1", features = ["serde"] }
+serde_yaml = "0.9"
 
 [dev-dependencies]
 tempfile = "3.12.0"


### PR DESCRIPTION
This PR add a new feature simplifying detection/filtering rule writing. It allows specifying events to filter by their names instead of event id.

## Example: include

```yaml
name: log.mprotect_exec
params:
    filter: true
match-on:
    events:
        kunai:
            - mprotect_exec
```

## Example: exclude

```yaml
name: exclude.mprotect_exec
params:
    filter: true
match-on:
    events:
        kunai:
            # there is a - in front of event name  
            - -mprotect_exec
```