### PR TITLE
fix: proc-macro building + completion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,5 @@
   "rust-analyzer.runnables.extraArgs": [
     "--target=x86_64-unknown-linux-gnu"
   ],
-  "rust-analyzer.procMacro.enable": false,
+  "rust-analyzer.procMacro.enable": true,
 }

--- a/kunai-ebpf/rust-toolchain.toml
+++ b/kunai-ebpf/rust-toolchain.toml
@@ -1,4 +1,7 @@
 [toolchain]
+# this channel needs to be aligned with the 
+# one in workspace if we want to benefit from
+# proc-macro analysis
 channel = "nightly-2024-07-07"
 
 # The source code of rustc, provided by the rust-src component, is needed for

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,8 @@
 [toolchain]
-channel = "1.80"
+# this channel needs to be aligned with the 
+# one in kunai-ebpf if we want to benefit from
+# proc-macro analysis
+channel = "nightly-2024-07-07"
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
 
 # to have the necessary for code analysis

--- a/xtask/src/user.rs
+++ b/xtask/src/user.rs
@@ -148,6 +148,14 @@ fn cargo(command: &str, opts: &BuildOptions) -> Result<(), anyhow::Error> {
         rustflags.push(format!("-C linker={linker}"))
     }
 
+    let cargo_version = Command::new("cargo").arg("-V").output()?;
+
+    // address issue when building yara with rust nightly
+    // https://github.com/VirusTotal/yara-x/issues/217
+    if String::from_utf8(cargo_version.stdout)?.contains("nightly") {
+        rustflags.push("-C link-args=-znostart-stop-gc".into());
+    }
+
     args.push(format!("--target={}", opts.target));
 
     opts.build_args.iter().for_each(|ba| args.push(ba.clone()));


### PR DESCRIPTION
This PR is in standby as enabling proc-macro seems to be an issue for `kunai-ebpf`: there are warning for every single proc-macro use in this part of the project.