### PR TITLE
fix: event processing

### DIFF
--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -61,10 +61,11 @@ pub enum Type {
     Execve,
     #[str("execve_script")]
     ExecveScript,
-    #[str("task_sched")]
-    TaskSched,
+    // there is hole here on purpose
+    // it used to be the spot of task_sched
+    // but it didn't aim at being configurable
     #[str("exit")]
-    Exit,
+    Exit = 4, // we start at 4 as we moved one event type
     #[str("exit_group")]
     ExitGroup,
     #[str("clone")]
@@ -81,8 +82,6 @@ pub enum Type {
     BpfProgLoad,
     #[str("bpf_socket_filter")]
     BpfSocketFilter,
-    //#[str("bpf_socket_prog")]
-    //BpfSocketProg,
 
     // memory stuffs
     #[str("mprotect_exec")]
@@ -125,6 +124,8 @@ pub enum Type {
     EndConfigurable = 1000,
 
     // specific events
+    #[str("task_sched")]
+    TaskSched,
     #[str("correlation")]
     Correlation,
     #[str("cache_hash")]

--- a/kunai-common/src/config.rs
+++ b/kunai-common/src/config.rs
@@ -41,16 +41,24 @@ impl Filter {
         }
     }
 
+    #[inline(always)]
     pub fn disable(&mut self, ty: bpf_events::Type) {
         self.enabled[ty as usize] = false;
     }
 
+    #[inline(always)]
     pub fn enable(&mut self, ty: bpf_events::Type) {
         self.enabled[ty as usize] = true;
     }
 
+    #[inline(always)]
     pub fn is_enabled(&self, ty: bpf_events::Type) -> bool {
         self.enabled[ty as usize]
+    }
+
+    #[inline(always)]
+    pub fn is_disabled(&self, ty: bpf_events::Type) -> bool {
+        !self.is_enabled(ty)
     }
 }
 


### PR DESCRIPTION
Minor changes in event processing:
- moved `execve`, `execve_script` and `clone` filtering in consumer as those are needed for correlation
- `task_sched` events are no longer filterable as they are needed for correlation