### PR TITLE
fix: display error field in FileMeta and in FileScanData

### DIFF
--- a/kunai/src/cache.rs
+++ b/kunai/src/cache.rs
@@ -52,7 +52,6 @@ pub struct FileMeta {
     pub sha256: String,
     pub sha512: String,
     pub size: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -993,7 +993,6 @@ pub struct FileScanData {
     pub signatures: Vec<String>,
     pub positives: usize,
     pub source_event: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub scan_error: Option<String>,
 }
 


### PR DESCRIPTION
fix issue #93