### PR TITLE
chg: config format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,7 +1428,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
  "uuid",
  "yara-x",
 ]
@@ -1445,6 +1444,7 @@ dependencies = [
  "dns-parser",
  "kunai-macros",
  "paste",
+ "serde",
  "thiserror",
  "uuid",
 ]
@@ -2393,15 +2393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,40 +2724,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
-dependencies = [
- "indexmap 2.4.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -3355,15 +3312,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-parser"

--- a/kunai-common/Cargo.toml
+++ b/kunai-common/Cargo.toml
@@ -10,19 +10,23 @@ publish = false
 
 [features]
 default = []
-user = ["aya", "dns-parser", "uuid", "thiserror"]
+user = ["aya", "dns-parser", "uuid", "thiserror", "serde"]
 
 [build-dependencies]
 bindgen = "0.69"
 
 [dependencies]
-# Non Aya deps
-dns-parser = { version = "0.8.0", optional = true }
+# optional deps (only for userland)
+thiserror = { version = "1.0", optional = true }
 uuid = { version = "1.3.0", optional = true, features = ["v4"] }
+dns-parser = { version = "0.8.0", optional = true }
+serde = { version = "1.0.164", features = ["derive"], optional = true }
+
+# Non Aya deps
 cfg-if = "1.0.0"
 paste = "1.0"
-thiserror = { version = "1.0", optional = true }
 kunai-macros = { path = "src/kunai-macros" }
+
 # Aya deps
 aya = { version = "0.12.0", optional = true }
 # we fix version including patch as some APIs got changed

--- a/kunai-common/src/bpf_events/user.rs
+++ b/kunai-common/src/bpf_events/user.rs
@@ -1,5 +1,7 @@
 use aya::Pod;
 use core::fmt::{Debug, Display};
+use core::str::FromStr;
+use serde::{Deserialize, Serialize};
 
 use thiserror::Error;
 
@@ -8,6 +10,25 @@ unsafe impl Pod for Type {}
 impl Display for Type {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl Serialize for Type {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Type {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Type::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -48,7 +48,6 @@ tokio = { version = "1.39", features = [
     "time",
     "sync",
 ] }
-toml = "0.7.4"
 serde = { version = "1.0.164", features = ["derive"] }
 clap = { version = "4.3.4", features = ["derive"] }
 serde_json = "1.0.108"


### PR DESCRIPTION
Changes configuration file format from `toml` to `yaml` prevents having several file format to support and to know (for end-user).

This PR also modifies the structure used to store event configuration. It got switched from `Vec` to `BTreeMap` (to keep events ordered)