### PR TITLE
feat(user): add a logs command in CLI

### DIFF
--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -2382,8 +2382,7 @@ struct InstallOpt {
 
 #[derive(Debug, Args)]
 struct LogsOpt {
-    /// Where to write the configuration file. Any intermediate directory
-    /// will be created if needed.
+    /// Path to the configuration file
     #[arg(short, long, default_value_t = String::from("/etc/kunai/config.yaml"))]
     config: String,
 }
@@ -2398,7 +2397,7 @@ enum Command {
     Replay(ReplayOpt),
     /// Dump a default configuration
     Config(ConfigOpt),
-    /// Easy way to show kunai logs. This will work only with a configuration file and with an output
+    /// Easy way to show Kunai logs. This will work only with a configuration file and with an output
     /// file being configured.
     Logs(LogsOpt),
 }

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -2849,10 +2849,13 @@ WantedBy=sysinit.target"#,
         let reader = BufReader::new(fd);
 
         for line in reader.lines() {
-            println!(
-                "{}",
-                line.map_err(|e| anyhow!("failed to read log file:{e}"))?
-            );
+            let line = line.map_err(|e| anyhow!("failed to read log file:{e}"))?;
+
+            // depending how the service got stopped some null
+            // bytes may appear in stop / start transition
+            let line = line.trim_matches('\0');
+
+            println!("{line}",);
         }
 
         Ok(())

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -44,7 +44,7 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use std::fs::{self, DirBuilder, File};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::IpAddr;
 
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
@@ -2380,6 +2380,14 @@ struct InstallOpt {
     enable_unit: bool,
 }
 
+#[derive(Debug, Args)]
+struct LogsOpt {
+    /// Where to write the configuration file. Any intermediate directory
+    /// will be created if needed.
+    #[arg(short, long, default_value_t = String::from("/etc/kunai/config.yaml"))]
+    config: String,
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Install Kunai on the system
@@ -2390,6 +2398,9 @@ enum Command {
     Replay(ReplayOpt),
     /// Dump a default configuration
     Config(ConfigOpt),
+    /// Easy way to show kunai logs. This will work only with a configuration file and with an output
+    /// file being configured.
+    Logs(LogsOpt),
 }
 
 impl Command {
@@ -2804,6 +2815,38 @@ WantedBy=sysinit.target"#,
 
         Self::systemd_install(&co, &install_bin, &config_path)
     }
+
+    fn logs(o: LogsOpt) -> anyhow::Result<()> {
+        let config: Config = serde_yaml::from_reader(
+            File::open(o.config).map_err(|e| anyhow!("failed to read config file: {e}"))?,
+        )
+        .map_err(|e| anyhow!("failed to parse config file: {e}"))?;
+
+        let output = PathBuf::from(config.output);
+        if !output.is_file() {
+            return Err(anyhow!(
+                "kunai output={} is not a regular file",
+                output.to_string_lossy()
+            ));
+        }
+
+        // for the time being kunai does not allow specifying custom
+        // log storage options so we can fix them
+        let fd = firo::OpenOptions::new()
+            .compression(firo::Compression::Gzip)
+            .open(&output)?;
+
+        let reader = BufReader::new(fd);
+
+        for line in reader.lines() {
+            println!(
+                "{}",
+                line.map_err(|e| anyhow!("failed to read log file:{e}"))?
+            );
+        }
+
+        Ok(())
+    }
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -2864,6 +2907,7 @@ fn main() -> Result<(), anyhow::Error> {
         Some(Command::Install(o)) => Command::install(o),
         Some(Command::Config(o)) => Command::config(o),
         Some(Command::Replay(o)) => Command::replay(o),
+        Some(Command::Logs(o)) => Command::logs(o),
         Some(Command::Run(o)) => Command::run(Some(o), verifier_level),
         None => Command::run(None, verifier_level),
     }


### PR DESCRIPTION
Kunai stores last logs in plain text but compresses old archives. It can be a burden to read the logs in the proper order for inspection. So this PR adds a new command in the CLI to read the logs and print them out (in good order) in the terminal.