### PR TITLE
fix(main): arbitrary ext ioc/rule file loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,9 +1050,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-walk"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374863c473230fd79ba996708da75f971f3a611470d2dced5161430201edac02"
+checksum = "445ee222cddb7095a1c08f94b6fe4926e2c93b389c4f71b65ab38bfa19227f48"
 
 [[package]]
 name = "fs4"

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -463,7 +463,10 @@ impl<'s> EventConsumer<'s> {
 
         for p in self.config.rules.clone().iter().map(PathBuf::from) {
             if !p.exists() {
-                error!("kunai rule file {} does not exist", p.to_string_lossy());
+                error!(
+                    "kunai rule loader: no such file or directory {}",
+                    p.to_string_lossy()
+                );
             } else if p.is_file() {
                 // we load file regardless of its extension
                 self.load_kunai_rule_file(p)?;
@@ -498,7 +501,10 @@ impl<'s> EventConsumer<'s> {
 
         for p in self.config.iocs.clone().iter().map(PathBuf::from) {
             if !p.exists() {
-                error!("no such ioc file or directory: {}", p.to_string_lossy())
+                error!(
+                    "ioc file loader: no such file or directory {}",
+                    p.to_string_lossy()
+                )
             } else if p.is_file() {
                 self.load_iocs(&p)
                     .map_err(|e| anyhow!("failed to load IoC file {}: {e}", p.to_string_lossy()))?;

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -383,6 +383,66 @@ impl<'s> EventConsumer<'s> {
         Ok(())
     }
 
+    fn load_kunai_rule_file<P: AsRef<Path>>(&mut self, rule_file: P) -> anyhow::Result<()> {
+        let rule_file = rule_file.as_ref();
+
+        info!(
+            "loading detection/filter rules from: {}",
+            rule_file.to_string_lossy()
+        );
+
+        for document in serde_yaml::Deserializer::from_reader(File::open(rule_file)?) {
+            // we deserialize into a value so that we can process string event ids
+            let mut value = serde_yaml::Value::deserialize(document)?;
+
+            // get rule name. We don't check here if there is a name as
+            // later parsing is supposed to catch it.
+            let rule_name = value
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or(String::from("unknown"));
+
+            if let Some(events) = value
+                .get_mut("match-on")
+                .and_then(|mo| mo.get_mut("events"))
+                .and_then(|e| e.get_mut("kunai"))
+                .and_then(|events| events.as_sequence_mut())
+            {
+                for v in events.iter_mut() {
+                    // we handle string event name
+                    if let Some(event_name) = v.as_str() {
+                        let id = if event_name.starts_with('-') {
+                            let event_name = event_name.trim_start_matches('-');
+                            let ty = Type::from_str(event_name)
+                                        .map_err(|_| {anyhow!("file={} rule={rule_name} parse error: unknown event name {event_name}",rule_file.to_string_lossy())})?;
+                            -i64::from(ty as u32)
+                        } else {
+                            let ty = Type::from_str(event_name).map_err(|_| {
+                                        anyhow!("file={} rule={rule_name} parse error: unknown event name {event_name}",rule_file.to_string_lossy())
+                                    })?;
+                            i64::from(ty as u32)
+                        };
+
+                        // we actually replace string by i64
+                        *v = serde_yaml::Value::Number(id.into());
+                    }
+                }
+            }
+
+            // we insert rule into the engine
+            self.engine
+                .insert_rule(gene::Rule::deserialize(value).map_err(|e| {
+                    anyhow!(
+                        "file={} rule={rule_name} parse error: {e}",
+                        rule_file.to_string_lossy()
+                    )
+                })?)?;
+        }
+
+        Ok(())
+    }
+
     fn init_event_scanner(&mut self) -> anyhow::Result<()> {
         // loading rules in the engine
         if self.config.rules.is_empty() {
@@ -394,68 +454,24 @@ impl<'s> EventConsumer<'s> {
             .files()
             // will list only files
             // with following extensions
+            .extension("kun")
+            .extension("kunai")
             .extension("gen")
             .extension("gene")
             // don't go recursive
             .max_depth(0);
 
-        for p in self.config.rules.iter() {
-            let w = wo.clone().walk(p);
-            for r in w {
-                let rule_file = r?;
-
-                info!(
-                    "loading detection/filter rules from: {}",
-                    rule_file.to_string_lossy()
-                );
-
-                for document in serde_yaml::Deserializer::from_reader(File::open(&rule_file)?) {
-                    // we deserialize into a value so that we can process string event ids
-                    let mut value = serde_yaml::Value::deserialize(document)?;
-
-                    // get rule name. We don't check here if there is a name as
-                    // later parsing is supposed to catch it.
-                    let rule_name = value
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                        .unwrap_or(String::from("unknown"));
-
-                    if let Some(events) = value
-                        .get_mut("match-on")
-                        .and_then(|mo| mo.get_mut("events"))
-                        .and_then(|e| e.get_mut("kunai"))
-                        .and_then(|events| events.as_sequence_mut())
-                    {
-                        for v in events.iter_mut() {
-                            // we handle string event name
-                            if let Some(event_name) = v.as_str() {
-                                let id = if event_name.starts_with('-') {
-                                    let event_name = event_name.trim_start_matches('-');
-                                    let ty = Type::from_str(event_name)
-                                        .map_err(|_| {anyhow!("file={} rule={rule_name} parse error: unknown event name {event_name}",rule_file.to_string_lossy())})?;
-                                    -i64::from(ty as u32)
-                                } else {
-                                    let ty = Type::from_str(event_name).map_err(|_| {
-                                        anyhow!("file={} rule={rule_name} parse error: unknown event name {event_name}",rule_file.to_string_lossy())
-                                    })?;
-                                    i64::from(ty as u32)
-                                };
-
-                                // we actually replace string by i64
-                                *v = serde_yaml::Value::Number(id.into());
-                            }
-                        }
-                    }
-
-                    // we insert rule into the engine
-                    self.engine
-                        .insert_rule(gene::Rule::deserialize(value).map_err(|e| {
-                            anyhow!(
-                                "file={} rule={rule_name} parse error: {e}",
-                                rule_file.to_string_lossy()
-                            )
-                        })?)?;
+        for p in self.config.rules.clone().iter().map(PathBuf::from) {
+            if !p.exists() {
+                error!("kunai rule file {} does not exist", p.to_string_lossy());
+            } else if p.is_file() {
+                // we load file regardless of its extension
+                self.load_kunai_rule_file(p)?;
+            } else if p.is_dir() {
+                // we walk the directory
+                let w = wo.clone().walk(p);
+                for r in w {
+                    self.load_kunai_rule_file(r?)?;
                 }
             }
         }
@@ -1530,6 +1546,7 @@ impl<'s> EventConsumer<'s> {
             // we run through event scanning engine
             let got_printed = self.scan_and_print(&mut event);
 
+            // we can force printing positive scans even if there is no filtering rule
             if !got_printed && self.config.always_show_positive_scans {
                 match serde_json::to_string(&event) {
                     Ok(ser) => writeln!(self.output, "{ser}").expect("failed to write json event"),


### PR DESCRIPTION
Support arbitrary file extension for rule/ioc files when these are configured by file only.