### PR TITLE
feat: new ptrace security event

### DIFF
--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -74,6 +74,8 @@ pub enum Type {
     Prctl,
     #[str("kill")]
     Kill,
+    #[str("ptrace")]
+    Ptrace,
 
     // stuff loaded in kernel
     #[str("init_module")]

--- a/kunai-common/src/bpf_events/events.rs
+++ b/kunai-common/src/bpf_events/events.rs
@@ -36,6 +36,8 @@ mod syscore_resume;
 pub use syscore_resume::*;
 mod kill;
 pub use kill::*;
+mod ptrace;
+pub use ptrace::*;
 
 // prevent using correlation event in bpf code
 not_bpf_target_code! {
@@ -66,6 +68,7 @@ const fn max_bpf_event_size() -> usize {
             Type::Clone => CloneEvent::size_of(),
             Type::Prctl => PrctlEvent::size_of(),
             Type::Kill => KillEvent::size_of(),
+            Type::Ptrace => PtraceEvent::size_of(),
             Type::InitModule => InitModuleEvent::size_of(),
             Type::BpfProgLoad => BpfProgLoadEvent::size_of(),
             Type::BpfSocketFilter => BpfSocketFilterEvent::size_of(),

--- a/kunai-common/src/bpf_events/events/ptrace.rs
+++ b/kunai-common/src/bpf_events/events/ptrace.rs
@@ -1,0 +1,9 @@
+use crate::bpf_events::{Event, TaskInfo};
+
+pub type PtraceEvent = Event<PtraceData>;
+
+#[repr(C)]
+pub struct PtraceData {
+    pub mode: u32,
+    pub target: TaskInfo,
+}

--- a/kunai-ebpf/src/probes.rs
+++ b/kunai-ebpf/src/probes.rs
@@ -30,6 +30,7 @@ mod lsm;
 mod mmap;
 mod mprotect;
 mod prctl;
+mod ptrace;
 mod schedule;
 mod send_data;
 mod syscore_resume;

--- a/kunai-ebpf/src/probes/ptrace.rs
+++ b/kunai-ebpf/src/probes/ptrace.rs
@@ -1,0 +1,44 @@
+use aya_ebpf::{cty::c_uint, programs::ProbeContext};
+
+use super::*;
+
+#[kprobe(function = "security_ptrace_access_check")]
+pub fn kprobe_ptrace_access_check(ctx: ProbeContext) -> u32 {
+    if is_current_loader_task() {
+        return 0;
+    }
+
+    match unsafe { try_ptrace_access_check(&ctx) } {
+        Ok(_) => errors::BPF_PROG_SUCCESS,
+        Err(s) => {
+            error!(&ctx, s);
+            errors::BPF_PROG_FAILURE
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn try_ptrace_access_check(ctx: &ProbeContext) -> Result<(), ProbeError> {
+    let target = co_re::task_struct::from_ptr(kprobe_arg!(ctx, 0)?);
+    let mode: c_uint = kprobe_arg!(ctx, 1)?;
+
+    // only catch PTRACE_MODE_ATTACH
+    if mode & 0x2 != 0x2 {
+        return Ok(());
+    }
+
+    // initialize allocator
+    alloc::init()?;
+    // alloc a new event
+    let event = alloc::alloc_zero::<PtraceEvent>()?;
+    // initialize eventc
+    event.init_from_current_task(Type::Ptrace)?;
+    // ptrace mode
+    event.data.mode = mode;
+    // initialize target task
+    event.data.target.from_task(target)?;
+
+    pipe_event(ctx, event);
+
+    Ok(())
+}

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -560,6 +560,23 @@ impl Scannable for KillData {
 impl_std_iocs!(KillData);
 
 def_user_data!(
+    pub struct PtraceData {
+        #[serde(with = "u32_hex")]
+        pub mode: u32,
+        pub target: TargetTask,
+    }
+);
+
+impl Scannable for PtraceData {
+    #[inline]
+    fn scannable_files(&self) -> Vec<Cow<'_, PathBuf>> {
+        vec![Cow::Borrowed(&self.exe.path)]
+    }
+}
+
+impl_std_iocs!(PtraceData);
+
+def_user_data!(
     pub struct MmapExecData {
         pub mapped: Hashes,
     }


### PR DESCRIPTION
Generate a kunai event when a process issues a ptrace syscall.

NB: so far the events fires up only when PTRACE_MODE_ATTACH: https://elixir.bootlin.com/linux/v6.11.5/source/include/linux/ptrace.h#L63