### PR TITLE
refactor: write_and_close -> write_close

### DIFF
--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -113,7 +113,7 @@ pub enum Type {
     FileRename,
     #[str("file_unlink")]
     FileUnlink,
-    #[str("write_and_close")]
+    #[str("write_close")]
     WriteAndClose,
 
     // specific userland events


### PR DESCRIPTION
Rename `write_and_close` event to be more coherent with previous event name convention such as `mmap_exec`, `mprotect_exec`.