### PR TITLE
fix(user): avoid using serde(flatten) in events

### DIFF
--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -753,22 +753,20 @@ impl<'s> EventConsumer<'s> {
         if let Some(ns) = ns {
             match self.cache.get_or_cache_in_ns(ns, p) {
                 Ok(h) => h,
-                Err(e) => Hashes {
-                    path: p.to_path_buf().clone(),
-                    meta: FileMeta {
+                Err(e) => {
+                    let meta = FileMeta {
                         error: Some(format!("{e}")),
                         ..Default::default()
-                    },
-                },
+                    };
+                    Hashes::with_meta(p.to_path_buf().clone(), meta)
+                }
             }
         } else {
-            Hashes {
-                path: p.to_path_buf().clone(),
-                meta: FileMeta {
-                    error: Some("unknown namespace".into()),
-                    ..Default::default()
-                },
-            }
+            let meta = FileMeta {
+                error: Some("unknown namespace".into()),
+                ..Default::default()
+            };
+            Hashes::with_meta(p.to_path_buf().clone(), meta)
         }
     }
 

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -1015,9 +1015,10 @@ pub struct FileScanData {
 
 impl FileScanData {
     pub fn from_hashes(h: Hashes) -> Self {
+        let p = h.path.clone();
         Self {
-            path: h.path,
-            meta: h.meta,
+            path: p,
+            meta: h.into(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
Due to a `serde(flatten)` directive in one of the kunai event it was impossible to match hash fields and error under `execve`, `execve_script` and `mmap_exec`.

A fix not to use `serde(flatten)` has been implemented.

Note: do not use `serde(flatten)` in kunai events as it breaks rule matching