### PR TITLE
fix: ancestors and parent_exe for zombie process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kunai"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "aya",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "kunai-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "kunai-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,9 +1070,9 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "fs-walk"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ee222cddb7095a1c08f94b6fe4926e2c93b389c4f71b65ab38bfa19227f48"
+checksum = "b916d76dbd9446be6a7266359cf633cad350b61a96ac7ff936d13c24f88cf4bc"
 
 [[package]]
 name = "fs4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["kunai", "kunai-common", "xtask"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Quentin JEROME <qjerome@rawsec.lu>"]
 license = "GPL-3.0"

--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -167,6 +167,8 @@ pub struct Namespaces {
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TaskInfo {
+    // this flag is used/set in userland only
+    pub zombie: bool,
     pub flags: u32,
     pub comm: [u8; COMM_SIZE],
     pub uid: u32,

--- a/kunai-ebpf/Cargo.toml
+++ b/kunai-ebpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kunai-ebpf"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Package containing eBPF code used by Kunai"
 authors = ["Quentin JEROME <qjerome@rawsec.lu>"]

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1447,10 +1447,10 @@ impl<'s> EventConsumer<'s> {
             .tasks
             .get(&std_info.task_key())
             .and_then(|t| {
-                if !t.is_zombie() {
-                    None
-                } else {
+                if t.real_parent_key.is_some() && t.real_parent_key != Some(std_info.parent_key()) {
                     t.real_parent_key
+                } else {
+                    None
                 }
             })
             // we get real parent

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -68,10 +68,10 @@ impl From<&StdEventInfo> for EventSection {
     fn from(value: &StdEventInfo) -> Self {
         Self {
             source: "kunai".into(),
-            id: value.info.etype.id(),
-            name: value.info.etype.to_string(),
-            uuid: value.info.uuid.into_uuid().hyphenated().to_string(),
-            batch: value.info.batch,
+            id: value.bpf.etype.id(),
+            name: value.bpf.etype.to_string(),
+            uuid: value.bpf.uuid.into_uuid().hyphenated().to_string(),
+            batch: value.bpf.batch,
         }
     }
 }
@@ -98,6 +98,7 @@ pub struct TaskSection {
     pub namespaces: Option<NamespaceInfo>,
     #[serde(with = "u32_hex")]
     pub flags: u32,
+    pub zombie: bool,
 }
 
 impl From<kunai_common::bpf_events::TaskInfo> for TaskSection {
@@ -111,6 +112,7 @@ impl From<kunai_common::bpf_events::TaskInfo> for TaskSection {
             gid: value.gid,
             namespaces: value.namespaces.map(|ns| ns.into()),
             flags: value.flags,
+            zombie: value.zombie,
         }
     }
 }
@@ -196,13 +198,13 @@ impl From<StdEventInfo> for EventInfo {
             },
             event: EventSection {
                 source: "kunai".into(),
-                id: value.info.etype.id(),
-                name: value.info.etype.to_string(),
-                uuid: value.info.uuid.into_uuid().hyphenated().to_string(),
-                batch: value.info.batch,
+                id: value.bpf.etype.id(),
+                name: value.bpf.etype.to_string(),
+                uuid: value.bpf.uuid.into_uuid().hyphenated().to_string(),
+                batch: value.bpf.batch,
             },
-            task: value.info.process.into(),
-            parent_task: value.info.parent.into(),
+            task: value.bpf.process.into(),
+            parent_task: value.bpf.parent.into(),
             utc_time: value.utc_timestamp.into(),
         }
     }

--- a/kunai/src/info.rs
+++ b/kunai/src/info.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use chrono::{DateTime, Utc};
 use kunai_common::{
-    bpf_events::{self, EventInfo},
+    bpf_events::{self, EventInfo, TaskInfo},
     uuid::TaskUuid,
 };
 use thiserror::Error;
@@ -68,20 +68,30 @@ pub struct AdditionalInfo {
 
 #[derive(Default, Debug, Clone)]
 pub struct StdEventInfo {
-    pub info: bpf_events::EventInfo,
+    pub bpf: bpf_events::EventInfo,
     pub additional: AdditionalInfo,
     pub utc_timestamp: DateTime<Utc>,
 }
 
 impl StdEventInfo {
     #[inline(always)]
+    pub fn task_info(&self) -> &TaskInfo {
+        &self.bpf.process
+    }
+
+    #[inline(always)]
+    pub fn parent_info(&self) -> &TaskInfo {
+        &self.bpf.parent
+    }
+
+    #[inline(always)]
     pub fn task_key(&self) -> TaskKey {
-        TaskKey::from(self.info.process.tg_uuid)
+        TaskKey::from(self.task_info().tg_uuid)
     }
 
     #[inline(always)]
     pub fn parent_key(&self) -> TaskKey {
-        TaskKey::from(self.info.parent.tg_uuid)
+        TaskKey::from(self.parent_info().tg_uuid)
     }
 
     #[inline]
@@ -90,7 +100,7 @@ impl StdEventInfo {
         info.set_uuid_random(rand);
 
         StdEventInfo {
-            info,
+            bpf: info,
             // on older kernels bpf_ktime_get_boot_ns() is not available so it is not
             // easy to compute correct event timestamp from eBPF so utc_timestamp is
             // the time at which the event is processed.

--- a/kunai/src/info.rs
+++ b/kunai/src/info.rs
@@ -16,6 +16,7 @@ pub struct TaskKey {
 }
 
 impl From<TaskUuid> for TaskKey {
+    #[inline(always)]
     fn from(value: TaskUuid) -> Self {
         // in task_struct start_time has a higher resolution so we need to scale it
         // down in order to have a comparable value with the procfs one
@@ -36,6 +37,7 @@ pub enum KeyError {
 
 impl TryFrom<&procfs::process::Process> for TaskKey {
     type Error = KeyError;
+    #[inline(always)]
     fn try_from(p: &procfs::process::Process) -> Result<Self, Self::Error> {
         let stat = p.stat()?;
         // panic here if we cannot get CLK_TCK


### PR DESCRIPTION
For zombie processes `ancestors` and `parent_exe` were not the "real" ones.

The purpose of making a zombie process is making difficult to track the real **parent/child** relationship. However in kunai we have the data to recover the real **parent/child** relationships across the full chains of ancestors of a given process.

**Prior to this PR**: kunai is computing `ancestors` and `parent_exe` from the `parent_task` returned by the kernel. The drawback with this approach is that when the process becomes a zombie the kernel sets `parent` to **init process** and we lose track of the real origin of the process.

**This PR** addresses this issue and puts the real `ancestors` and real `parent_exe` in events' fields

Using real `ancestors` and `parent_exe` introduces some inconsistencies in the events. After the fix `.info.parent_task` section does not show relevant information as it contains task information collected in kernel. So, this needs to be addressed too to reflect **real** parent task.

Finally, when replacing `.info.parent_task` with the **real parent information** completely hides the fact the task is a zombie, simply because we fixed everything up to resolve zombification. This is not desired as zombie tasks are not so frequent under regular circumstances but often used by malware. So we propose to add a `.info.task.zombie` and `.info.parent_task.zombie` fields (booleans) to show when a task or its parent is a zombie process.

To sum up this PR addresses:
1. put **real ancestors** (will not be init if task is zombie) in `.data.ancestors` field
2. put **real parent exe** in `.data.parent_exe` for `execve` and `execve_script` events
3. fixes `.info.parent_task` to be the **real** parent task
4. introduces `.info.task.zombie` and `.info.parent_task.zombie` boolean flags to identify when a task is a zombie
5. some minor refactoring to implement all this

