### PR TITLE
feat: limit i/o related events

### DIFF
--- a/kunai-common/src/co_re/c/shim.c
+++ b/kunai-common/src/co_re/c/shim.c
@@ -115,13 +115,24 @@ _SHIM_GETTER_BPF_CORE_READ(gid_t, shim_cred_gid(struct cred *pcred), pcred, gid.
 
 struct qstr
 {
-	__u64 hash_len;
+	union
+	{
+		__u64 hash_len;
+		struct
+		{
+			u32 hash;
+			u32 len;
+		};
+	};
+
 	const unsigned char *name;
 }
 __attribute__((preserve_access_index));
 
 SHIM(qstr, name);
 SHIM(qstr, hash_len);
+SHIM(qstr, hash);
+SHIM(qstr, len);
 
 struct vfsmount
 {

--- a/kunai-common/src/co_re/core_fs.rs
+++ b/kunai-common/src/co_re/core_fs.rs
@@ -93,17 +93,8 @@ pub type qstr = CoRe<gen::qstr>;
 impl qstr {
     rust_shim_kernel_impl!(pub, qstr, name, *const u8);
     rust_shim_kernel_impl!(pub, qstr, hash_len, u64);
-
-    #[inline(always)]
-    pub unsafe fn hash(&self) -> Option<u32> {
-        Some(self.hash_len()? as u32)
-    }
-
-    #[inline(always)]
-    pub unsafe fn len(&self) -> Option<u32> {
-        //(shim_qstr_hash_len(self.as_ptr_mut()) >> 32) as u32
-        Some((self.hash_len()? >> 32) as u32)
-    }
+    rust_shim_kernel_impl!(pub, qstr, hash, u32);
+    rust_shim_kernel_impl!(pub, qstr, len, u32);
 }
 
 #[allow(non_camel_case_types)]

--- a/kunai-common/src/co_re/gen.rs
+++ b/kunai-common/src/co_re/gen.rs
@@ -1,6 +1,7 @@
 pub type __u64 = ::core::ffi::c_ulonglong;
 pub type u64_ = __u64;
 pub type __u32 = ::core::ffi::c_uint;
+pub type u32_ = __u32;
 pub type __u16 = ::core::ffi::c_ushort;
 pub type u16_ = __u16;
 pub type __u8 = ::core::ffi::c_uchar;
@@ -42,10 +43,22 @@ extern "C" {
     pub fn shim_cred_gid(pcred: *mut cred) -> gid_t;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct qstr {
-    pub hash_len: __u64,
+    pub __bindgen_anon_1: qstr__bindgen_ty_1,
     pub name: *const ::core::ffi::c_uchar,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union qstr__bindgen_ty_1 {
+    pub hash_len: __u64,
+    pub __bindgen_anon_1: qstr__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct qstr__bindgen_ty_1__bindgen_ty_1 {
+    pub hash: u32_,
+    pub len: u32_,
 }
 extern "C" {
     pub fn shim_qstr_name(qstr: *mut qstr) -> *const ::core::ffi::c_uchar;
@@ -64,6 +77,24 @@ extern "C" {
 }
 extern "C" {
     pub fn shim_qstr_hash_len_exists(qstr: *mut qstr) -> bool;
+}
+extern "C" {
+    pub fn shim_qstr_hash(qstr: *mut qstr) -> ::core::ffi::c_uint;
+}
+extern "C" {
+    pub fn shim_qstr_hash_user(qstr: *mut qstr) -> ::core::ffi::c_uint;
+}
+extern "C" {
+    pub fn shim_qstr_hash_exists(qstr: *mut qstr) -> bool;
+}
+extern "C" {
+    pub fn shim_qstr_len(qstr: *mut qstr) -> ::core::ffi::c_uint;
+}
+extern "C" {
+    pub fn shim_qstr_len_user(qstr: *mut qstr) -> ::core::ffi::c_uint;
+}
+extern "C" {
+    pub fn shim_qstr_len_exists(qstr: *mut qstr) -> bool;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -141,7 +172,7 @@ extern "C" {
     pub fn shim_super_block_s_root_exists(super_block: *mut super_block) -> bool;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct dentry {
     pub d_flags: ::core::ffi::c_uint,
     pub d_parent: *mut dentry,

--- a/kunai-common/src/config.rs
+++ b/kunai-common/src/config.rs
@@ -67,6 +67,7 @@ impl Filter {
 pub struct BpfConfig {
     pub loader: Loader,
     pub filter: Filter,
-    pub max_eps_io: Option<u64>,
+    pub glob_max_eps_io: Option<u64>,
+    pub task_max_eps_io: Option<u64>,
     pub send_data_min_len: u64,
 }

--- a/kunai-common/src/config.rs
+++ b/kunai-common/src/config.rs
@@ -67,5 +67,6 @@ impl Filter {
 pub struct BpfConfig {
     pub loader: Loader,
     pub filter: Filter,
+    pub max_eps_io: Option<u64>,
     pub send_data_min_len: u64,
 }

--- a/kunai-common/src/path/bpf.rs
+++ b/kunai-common/src/path/bpf.rs
@@ -93,7 +93,7 @@ impl Path {
                 break;
             }
 
-            // read the qstr
+            // prepend path separator
             if !self.is_empty() {
                 self.prepend_path_sep()?;
             }

--- a/kunai-common/src/path/bpf.rs
+++ b/kunai-common/src/path/bpf.rs
@@ -14,33 +14,6 @@ fn xor_shift_star(a: u64, b: u64) -> u64 {
     return x * 0x2545F4914F6CDD1D;
 }
 
-#[allow(dead_code)]
-#[repr(C)]
-pub struct MapKey {
-    hash: u64,
-    // depth is a u32 to force structure alignment
-    // without this kernel 5.4 fails at using this
-    // struct
-    depth: u32,
-    len: u32,
-    ino: u64,
-    sb_ino: u64,
-}
-
-impl From<&Path> for MapKey {
-    #[inline(always)]
-    fn from(p: &Path) -> Self {
-        let meta = p.metadata.unwrap_or_default();
-        MapKey {
-            hash: p.hash,
-            depth: p.depth as u32,
-            len: p.len,
-            ino: meta.ino,
-            sb_ino: meta.sb_ino,
-        }
-    }
-}
-
 impl Path {
     #[inline(always)]
     unsafe fn init_from_inode(&mut self, i: &co_re::inode) -> Result<()> {
@@ -59,11 +32,6 @@ impl Path {
         });
 
         Ok(())
-    }
-
-    #[inline(always)]
-    pub fn map_key(&self) -> MapKey {
-        MapKey::from(self)
     }
 
     #[inline(always)]

--- a/kunai-ebpf/src/probes/fs.rs
+++ b/kunai-ebpf/src/probes/fs.rs
@@ -1,8 +1,12 @@
+use core::ops::Div;
+
 use super::*;
 
 use aya_ebpf::cty::c_int;
+use aya_ebpf::helpers::bpf_ktime_get_ns;
 use aya_ebpf::maps::LruHashMap;
 use aya_ebpf::programs::{ProbeContext, RetProbeContext};
+use aya_ebpf::EbpfContext;
 use kunai_common::inspect_err;
 use kunai_common::kprobe::ProbeFn;
 
@@ -77,6 +81,74 @@ unsafe fn file_key(file: &co_re::file) -> ProbeResult<FileKey> {
     Ok(FileKey(task_id, ino))
 }
 
+// (task_id, sampling_ts): counter
+#[map]
+static mut THROTTLE: LruHashMap<(u64, u64), u64> = LruHashMap::with_max_entries(0x1ffff, 0);
+
+const SAMPLING_NS: u64 = 100_000_000;
+const SAMPLES_IN_1S: u64 = 10;
+
+#[inline(always)]
+unsafe fn events_per_sampling(task_id: u64) -> u64 {
+    // sampling period of 10ms
+    let sampling_ts = bpf_ktime_get_ns().div(SAMPLING_NS);
+
+    let key = (task_id, sampling_ts);
+
+    if let Some(c) = THROTTLE.get_ptr_mut(&key) {
+        *c += 1;
+        *c
+    } else {
+        ignore_result!(THROTTLE.insert(&key, &1, 0));
+        1
+    }
+}
+
+#[inline(always)]
+unsafe fn is_task_io_limit_reach(limit: u64) -> (bool, bool) {
+    let eps = events_per_sampling(bpf_task_tracking_id());
+    if eps >= limit {
+        return (true, eps == limit);
+    }
+    (false, false)
+}
+
+#[inline(always)]
+unsafe fn is_global_io_limit_reach(limit: u64) -> (bool, bool) {
+    let eps = events_per_sampling(0);
+    if eps >= limit {
+        return (true, eps == limit);
+    }
+    (false, false)
+}
+
+#[inline(always)]
+unsafe fn limit_eps_with_context<C: EbpfContext>(ctx: &C) -> ProbeResult<bool> {
+    // we convert event/s to event/sampling
+    let Some(limit) = get_cfg!().map(|c| c.max_eps_io.map(|m| m.div(SAMPLES_IN_1S)))? else {
+        // if there is no limit we do not throttle
+        return Ok(false);
+    };
+
+    // we allow a process to take alone half of this otherwise we report it
+    if let (true, limit) = is_task_io_limit_reach(limit.div(2)) {
+        if limit {
+            error_msg!(ctx, "current task i/o limit reached");
+        }
+        return Ok(true);
+    }
+
+    // if there are too many I/O globally a random task can see its I/O ignored
+    if let (true, limit) = is_global_io_limit_reach(limit) {
+        if limit {
+            error_msg!(ctx, "global i/o limit reached");
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
 #[kprobe(function = "vfs_read")]
 pub fn fs_vfs_read(ctx: ProbeContext) -> u32 {
     if is_current_loader_task() {
@@ -133,6 +205,10 @@ unsafe fn try_vfs_read(ctx: &ProbeContext) -> ProbeResult<()> {
         event.init_from_current_task(Type::ReadConfig)?;
         pipe_event(ctx, event);
     } else if config.is_event_enabled(Type::Read) && !event.data.path.starts_with("/proc/") {
+        // we rate limit this event
+        if limit_eps_with_context(ctx)? {
+            return Ok(());
+        }
         // we filter out procfs because it generates too much events
         // maybe let the choice through a configuration option
         event.init_from_current_task(Type::Read)?;
@@ -207,6 +283,10 @@ unsafe fn try_vfs_write(ctx: &ProbeContext) -> ProbeResult<()> {
         event.init_from_current_task(Type::WriteConfig)?;
         pipe_event(ctx, event);
     } else if config.is_event_enabled(Type::Write) {
+        // we rate limit this event
+        if limit_eps_with_context(ctx)? {
+            return Ok(());
+        }
         event.init_from_current_task(Type::Write)?;
         pipe_event(ctx, event);
     }
@@ -246,6 +326,11 @@ unsafe fn try_security_path_rename(ctx: &ProbeContext) -> ProbeResult<()> {
 
     // we handle only file renaming for the moment
     if !core_read_kernel!(old_dentry, is_file)? {
+        return Ok(());
+    }
+
+    // we rate limit this event
+    if limit_eps_with_context(ctx)? {
         return Ok(());
     }
 
@@ -344,6 +429,11 @@ unsafe fn try_vfs_unlink(ctx: &RetProbeContext) -> ProbeResult<()> {
     // if event is disabled we return
     if_disabled_return!(Type::FileUnlink, ());
 
+    // we rate limit this event
+    if limit_eps_with_context(ctx)? {
+        return Ok(());
+    }
+
     let rc: c_int = ctx.ret().unwrap_or(-1);
 
     alloc::init()?;
@@ -410,6 +500,11 @@ pub fn fs_enter_fput_sync(ctx: ProbeContext) -> u32 {
     }
 }
 
+#[map]
+static mut WRITE_CLOSE_CACHE: LruHashMap<(u64, u64, path::MapKey), bool> =
+    LruHashMap::with_max_entries(4096, 0);
+
+#[inline(always)]
 unsafe fn try_enter_fput(ctx: &ProbeContext) -> ProbeResult<()> {
     // if event is disabled we return early
     if get_cfg!().map(|c| c.is_event_disabled(Type::WriteClose))? {
@@ -438,6 +533,27 @@ unsafe fn try_enter_fput(ctx: &ProbeContext) -> ProbeResult<()> {
         event.data.path.core_resolve_file(&file, MAX_PATH_DEPTH),
         |e: &path::Error| warn!(ctx, "failed to resolve filename", (*e).into())
     ));
+
+    // we create a unique key for path
+    let k = (
+        bpf_ktime_get_ns().div(100_000_000),
+        bpf_task_tracking_id(),
+        event.data.path.map_key(),
+    );
+
+    // we already generated an event for this path less than 100ms ago
+    // so we ignore it
+    if WRITE_CLOSE_CACHE.get(&k).is_some() {
+        return Ok(());
+    }
+
+    ignore_result!(WRITE_CLOSE_CACHE.insert(&k, &true, 0));
+
+    // make this check only here as we want to filter out
+    // already known paths first
+    if limit_eps_with_context(ctx)? {
+        return Ok(());
+    }
 
     // we send event
     pipe_event(ctx, event);
@@ -474,6 +590,11 @@ unsafe fn try_security_file_open(ctx: &ProbeContext) -> ProbeResult<()> {
 
     // if not FMODE_CREATED we return
     if !file.f_mode().unwrap_or_default() & FMODE_CREATED == FMODE_CREATED {
+        return Ok(());
+    }
+
+    // we rate limit this event
+    if limit_eps_with_context(ctx)? {
         return Ok(());
     }
 

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -2606,6 +2606,10 @@ struct RunOpt {
     #[arg(long)]
     max_buffered_events: Option<u16>,
 
+    /// Set a maximum number of events per seconds for I/O events
+    #[arg(long)]
+    max_eps_io: Option<u64>,
+
     /// Minimum amount of data sent to trigger a send_data event,
     /// set it to 0 to get all send_data events.
     #[arg(long)]
@@ -2665,6 +2669,11 @@ impl TryFrom<RunOpt> for Config {
         // we want to increase max_buffered_events
         if let Some(max_buffered_events) = opt.max_buffered_events {
             conf.max_buffered_events = max_buffered_events;
+        }
+
+        // we want to increase max_buffered_events
+        if let Some(max_eps_io) = opt.max_eps_io {
+            conf.max_eps_io = Some(max_eps_io);
         }
 
         // supersedes configuration

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -2606,7 +2606,7 @@ struct RunOpt {
     #[arg(long)]
     max_buffered_events: Option<u16>,
 
-    /// Set a maximum number of events per seconds for I/O events
+    /// Set a maximum number of events per seconds and per CPU for I/O events
     #[arg(long)]
     max_eps_io: Option<u64>,
 

--- a/kunai/src/config.rs
+++ b/kunai/src/config.rs
@@ -62,6 +62,7 @@ pub struct Scanner {
 pub struct Config {
     host_uuid: Option<uuid::Uuid>,
     pub max_buffered_events: u16,
+    pub max_eps_io: Option<u64>,
     pub workers: Option<usize>,
     pub send_data_min_len: Option<u64>,
     pub harden: bool,
@@ -94,6 +95,7 @@ impl Default for Config {
                 buffered: false,
             },
             max_buffered_events: DEFAULT_MAX_BUFFERED_EVENTS,
+            max_eps_io: Some(10000),
             workers: None,
             send_data_min_len: None,
             scanner: Scanner {
@@ -211,6 +213,7 @@ impl TryFrom<&Config> for BpfConfig {
         Ok(Self {
             loader: Loader::from_own_pid(),
             filter: value.try_into()?,
+            max_eps_io: value.max_eps_io,
             send_data_min_len: value.send_data_min_len.unwrap_or(DEFAULT_SEND_DATA_MIN_LEN),
         })
     }

--- a/kunai/src/util.rs
+++ b/kunai/src/util.rs
@@ -5,11 +5,11 @@ use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 use std::{fs, io, net::IpAddr};
 
+pub mod account;
 pub mod bpf;
 pub mod elf;
 pub mod namespace;
 pub mod uname;
-pub mod account;
 
 #[inline]
 pub fn is_public_ip(ip: IpAddr) -> bool {


### PR DESCRIPTION
### Summary of Changes in This PR

This PR addresses the need to throttle I/O events to prevent event loss, which can disrupt Kunai's eBPF-based correlation mechanisms.

Event loss is problematic because Kunai relies on eBPF events to allocate and free structures used for correlation. Missing crucial events may lead to incomplete correlations or memory leaks.

I/O events, being among the fastest, can easily generate tens of thousands of events per second, quickly saturating the event buffer.

### Implemented Filtering Strategies

To mitigate event loss, this PR introduces the following filtering mechanisms:

- **De-duplication of `write_close` events**: Prevents redundant events from overwhelming the buffer.
- **Per-task I/O throttling**: Limits I/O events on a per-task basis, ensuring that excessive I/O from one task doesn't affect others.
- **Global I/O throttling**: Introduces random throttling of I/O events when they consume excessive buffer space.

These strategies aim to maintain efficient event processing while preserving crucial correlations.
