### PR TITLE
refactor: turn error event into log event

### DIFF
--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -134,8 +134,8 @@ pub enum Type {
     Correlation,
     #[str("cache_hash")]
     CacheHash,
-    #[str("error")]
-    Error,
+    #[str("log")]
+    Log,
     #[str("syscore_resume")]
     SyscoreResume,
 

--- a/kunai-common/src/bpf_events/events.rs
+++ b/kunai-common/src/bpf_events/events.rs
@@ -30,8 +30,8 @@ mod mount;
 pub use mount::*;
 mod prctl;
 pub use prctl::*;
-pub mod error;
-pub use error::{ErrorData, ErrorEvent};
+pub mod log;
+pub use log::{LogData, LogEvent};
 mod syscore_resume;
 pub use syscore_resume::*;
 mod kill;
@@ -85,7 +85,7 @@ const fn max_bpf_event_size() -> usize {
             | Type::FileCreate => FileEvent::size_of(),
             Type::FileRename => FileRenameEvent::size_of(),
             Type::FileUnlink => UnlinkEvent::size_of(),
-            Type::Error => ErrorEvent::size_of(),
+            Type::Log => LogEvent::size_of(),
             Type::SyscoreResume => SysCoreResumeEvent::size_of(),
             // these are event types only used in user land
             Type::Unknown

--- a/kunai-common/src/bpf_events/events/log.rs
+++ b/kunai-common/src/bpf_events/events/log.rs
@@ -5,16 +5,18 @@ use crate::{
     string::String,
 };
 
-pub type ErrorEvent = Event<ErrorData>;
+pub type LogEvent = Event<LogData>;
 
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub enum Level {
+    Info,
     Warn,
     Error,
 }
 
 #[repr(C)]
-pub struct ErrorData {
+pub struct LogData {
     pub location: String<32>,
     pub line: u32,
     pub level: Level,
@@ -28,7 +30,7 @@ bpf_target_code! {
 
     const DEFAULT_COMM: String<16> = string::from_static("?");
 
-    impl ErrorEvent {
+    impl LogEvent {
         #[inline(always)]
         pub fn init_with_level(&mut self, level: Level){
             let pid_tgid = bpf_get_current_pid_tgid();
@@ -41,7 +43,7 @@ bpf_target_code! {
 }
 
 not_bpf_target_code! {
-    impl core::fmt::Display for ErrorEvent {
+    impl core::fmt::Display for LogEvent {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(
                 f,

--- a/kunai-common/src/bpf_events/events/perfs.rs
+++ b/kunai-common/src/bpf_events/events/perfs.rs
@@ -4,7 +4,7 @@ pub const KUNAI_EVENTS_MAP: &str = "KUNAI_EVENTS";
 pub const KUNAI_STATS_MAP: &str = "KUNAI_STATS";
 
 bpf_target_code! {
-    use crate::bpf_events::{Event,Type, ErrorEvent};
+    use crate::bpf_events::{Event,Type, LogEvent};
     use aya_ebpf::{macros::map, maps::{HashMap,PerfEventByteArray}, EbpfContext};
 
     #[map(name = "KUNAI_EVENTS")]
@@ -15,7 +15,7 @@ bpf_target_code! {
 
 
     #[inline(always)]
-    pub unsafe fn pipe_error<C: EbpfContext>(ctx: &C, e: &ErrorEvent) {
+    pub unsafe fn pipe_log<C: EbpfContext>(ctx: &C, e: &LogEvent) {
         EVENTS.output(ctx, e.encode(), 0);
     }
 

--- a/kunai-ebpf/src/probes.rs
+++ b/kunai-ebpf/src/probes.rs
@@ -5,12 +5,12 @@ use kunai_common::{
     bpf_events::*,
     co_re,
     consts::*,
-    error, error_msg,
+    error,
     errors::{self, *},
     inspect_err,
     path::{self, *},
     utils::*,
-    warn, warn_msg,
+    warn,
 };
 
 #[cfg(feature = "debug")]

--- a/kunai-ebpf/src/probes/bpf.rs
+++ b/kunai-ebpf/src/probes/bpf.rs
@@ -72,7 +72,7 @@ unsafe fn try_bpf_prog_load(ctx: &RetProbeContext) -> ProbeResult<()> {
         if let Some(p_name) = bpf_prog_aux.name() {
             ignore_result!(inspect_err!(
                 event.data.name.read_kernel_str_bytes(p_name),
-                |_| warn_msg!(ctx, "failed to read program name")
+                |_| warn!(ctx, "failed to read program name")
             ));
         }
 
@@ -90,7 +90,7 @@ unsafe fn try_bpf_prog_load(ctx: &RetProbeContext) -> ProbeResult<()> {
         if let Some(afn) = bpf_prog_aux.attach_func_name() {
             ignore_result!(inspect_err!(
                 event.data.attached_func_name.read_kernel_str_bytes(afn),
-                |_| warn_msg!(ctx, "failed to read attach_func_name")
+                |_| warn!(ctx, "failed to read attach_func_name")
             ));
         }
 
@@ -102,7 +102,7 @@ unsafe fn try_bpf_prog_load(ctx: &RetProbeContext) -> ProbeResult<()> {
 
         pipe_event(ctx, event);
     } else {
-        error_msg!(ctx, "failed to retrieve BPF program load event")
+        error!(ctx, "failed to retrieve BPF program load event")
     }
 
     // we use a LruHashmap so we can safely ignore result

--- a/kunai-ebpf/src/probes/bpf_socket.rs
+++ b/kunai-ebpf/src/probes/bpf_socket.rs
@@ -122,7 +122,7 @@ unsafe fn handle_socket_attach_prog(
     }
 
     //handle loading of regular bpf program
-    warn_msg!(exit_ctx, "bpf program attached to socket not yet supported");
+    warn!(exit_ctx, "bpf program attached to socket not yet supported");
 
     Ok(())
 }

--- a/kunai-ebpf/src/probes/execve.rs
+++ b/kunai-ebpf/src/probes/execve.rs
@@ -131,7 +131,7 @@ unsafe fn execve_event<C: EbpfContext>(ctx: &C, rc: i32) -> ProbeResult<()> {
         .read_user_at(arg_start as *const u8, arg_len as u32)
         .is_err()
     {
-        warn_msg!(ctx, "failed to read argv")
+        warn!(ctx, "failed to read argv")
     }
 
     // cgroup parsing

--- a/kunai-ebpf/src/probes/fs.rs
+++ b/kunai-ebpf/src/probes/fs.rs
@@ -138,7 +138,7 @@ unsafe fn limit_eps_with_context<C: EbpfContext>(ctx: &C) -> ProbeResult<bool> {
     // we allow a process to take alone half of this otherwise we report it
     if let (true, limit) = is_task_io_limit_reach(task_limit) {
         if limit {
-            error_msg!(ctx, "current task i/o limit reached");
+            error!(ctx, "current task i/o limit reached");
         }
         return Ok(true);
     }
@@ -146,7 +146,7 @@ unsafe fn limit_eps_with_context<C: EbpfContext>(ctx: &C) -> ProbeResult<bool> {
     // if there are too many I/O globally a random task can see its I/O ignored
     if let (true, limit) = is_global_io_limit_reach(glob_limit) {
         if limit {
-            error_msg!(ctx, "global i/o limit reached");
+            error!(ctx, "global i/o limit reached");
         }
         return Ok(true);
     }
@@ -221,7 +221,7 @@ unsafe fn try_vfs_read(ctx: &ProbeContext) -> ProbeResult<()> {
     }
 
     // we mark file as being tracked
-    ignore_result!(inspect_err!(file_set_flag(&file, READ), |_| warn_msg!(
+    ignore_result!(inspect_err!(file_set_flag(&file, READ), |_| warn!(
         ctx,
         "failed to track file read"
     )));
@@ -297,7 +297,7 @@ unsafe fn try_vfs_write(ctx: &ProbeContext) -> ProbeResult<()> {
     }
 
     // we mark file as being tracked
-    ignore_result!(inspect_err!(file_set_flag(&file, WRITE), |_| warn_msg!(
+    ignore_result!(inspect_err!(file_set_flag(&file, WRITE), |_| warn!(
         ctx,
         "failed to track file write"
     )));

--- a/kunai-ebpf/src/probes/init_module.rs
+++ b/kunai-ebpf/src/probes/init_module.rs
@@ -97,7 +97,7 @@ unsafe fn handle_init_module(ctx: &TracePointContext, args: InitModuleArgs) -> P
             .data
             .uargs
             .read_user_str_bytes(args.uargs() as *const u8),
-        |_| warn_msg!(ctx, "failed to read uargs")
+        |_| warn!(ctx, "failed to read uargs")
     ));
 
     // setting event data

--- a/kunai-ebpf/src/probes/schedule.rs
+++ b/kunai-ebpf/src/probes/schedule.rs
@@ -97,7 +97,7 @@ unsafe fn try_schedule(ctx: &ProbeContext) -> ProbeResult<()> {
 
     // we do not really care if that is failing
     ignore_result!(inspect_err!(MARKED.insert(&task_uuid, &true, 0), |_| {
-        warn_msg!(ctx, "failed to track task")
+        warn!(ctx, "failed to track task")
     }));
 
     // we send event to userland

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -27,7 +27,7 @@ use kunai::util::uname::Utsname;
 use kunai::yara::{Scanner, SourceCode};
 use kunai::{cache, util};
 use kunai_common::bpf_events::{
-    self, error, event, mut_event, EncodedEvent, Event, PrctlOption, Signal, TaskInfo, Type,
+    self, event, mut_event, EncodedEvent, Event, PrctlOption, Signal, TaskInfo, Type,
     MAX_BPF_EVENT_SIZE,
 };
 use kunai_common::config::Filter;
@@ -2104,7 +2104,10 @@ impl EventConsumer<'_> {
                 Err(e) => error!("failed to decode {} event: {:?}", etype, e),
             },
 
-            Type::Error => panic!("error events should be processed earlier"),
+            Type::Log => {
+                #[cfg(debug_assertions)]
+                panic!("log events should be processed earlier")
+            }
             Type::SyscoreResume => { /*  just ignore it */ }
         }
     }
@@ -2295,11 +2298,12 @@ impl EventProducer {
                     }
                 }
             }
-            Type::Error => {
-                let e = event!(e, bpf_events::ErrorEvent).unwrap();
+            Type::Log => {
+                let e = event!(e, bpf_events::LogEvent).unwrap();
                 match e.data.level {
-                    error::Level::Warn => warn!("{}", e),
-                    error::Level::Error => error!("{}", e),
+                    bpf_events::log::Level::Info => info!("{}", e),
+                    bpf_events::log::Level::Warn => warn!("{}", e),
+                    bpf_events::log::Level::Error => error!("{}", e),
                 }
                 // we don't need to process such event further
                 return true;
@@ -2966,7 +2970,7 @@ impl Command {
                         Type::Unknown
                         | Type::CacheHash
                         | Type::Correlation
-                        | Type::Error
+                        | Type::Log
                         | Type::EndConfigurable
                         | Type::TaskSched
                         | Type::SyscoreResume


### PR DESCRIPTION
- more accurate terminology as a log can be either info/warn/error
- refactored eBPF error and warn macro to handle all the cases
- removed error_msg and warn_msg macros
- renamed structures and enums to turn "error" terminology to "log"