### PR TITLE
feat: new start event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,9 +1078,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gene"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fedeb5b685ac638aca2cf6472a26fffe9a38770de5d8ec5ef75d0904cc466a"
+checksum = "8b7c2d409104c5cf1ace9ec17e4a38dc859722f0fffcaa9d21e060499f8995f1"
 dependencies = [
  "gene_derive",
  "lazy_static",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "gene_derive"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3717a84661a0c5623336e77ce4f1b4ad9f973da48a4ba3250d516362592c152f"
+checksum = "57b65675f5cf61735bab23b0b1dcb654f75f96d3b23bf482c39ee36f28f0d9d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.0",
 ]

--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -134,6 +134,11 @@ pub enum Type {
     #[str("end_configurable")]
     EndConfigurable = 1000,
 
+    // Those events are not configurable but should have
+    // fix event number as these are displayed
+    #[str("start")]
+    Start,
+
     // specific events
     #[str("task_sched")]
     TaskSched,

--- a/kunai-common/src/bpf_events/events.rs
+++ b/kunai-common/src/bpf_events/events.rs
@@ -42,6 +42,8 @@ pub mod error;
 pub use error::*;
 mod loss;
 pub use loss::*;
+mod status;
+pub use status::*;
 
 // prevent using correlation event in bpf code
 not_bpf_target_code! {
@@ -90,6 +92,7 @@ const fn max_bpf_event_size() -> usize {
             Type::FileRename => FileRenameEvent::size_of(),
             Type::FileUnlink => UnlinkEvent::size_of(),
             Type::Log => LogEvent::size_of(),
+            Type::Start => StatusEvent::size_of(),
             Type::Loss => LossEvent::size_of(),
             Type::Error => ErrorEvent::size_of(),
             Type::SyscoreResume => SysCoreResumeEvent::size_of(),

--- a/kunai-common/src/bpf_events/events/status.rs
+++ b/kunai-common/src/bpf_events/events/status.rs
@@ -1,0 +1,5 @@
+use crate::bpf_events::Event;
+
+/// Event that must be used only in userland
+/// to encode status information
+pub type StatusEvent = Event<()>;

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -30,8 +30,8 @@ ip_network = "0.4"
 lru-st = { version = "0.2", features = ["sync"] }
 
 # detection engine for events
-gene = { version = "0.4.0" }
-gene_derive = { version = "0.4.0" }
+gene = { version = "0.4" }
+gene_derive = { version = "0.4" }
 
 anyhow = "1.0.68"
 env_logger = "0.10"

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -22,7 +22,7 @@ hex = "0.4.3"
 md-5 = "0.10.5"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
-chrono = { version = "0.4.24", features = ["clock"] }
+chrono = { version = "0.4.24", features = ["clock", "serde"] }
 libc = "0.2"
 thiserror = "1.0"
 procfs = "0.16"

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1411,7 +1411,7 @@ impl EventConsumer<'_> {
         if let Ok(uptime) = Uptime::from_sys().inspect_err(|e| error!("failed to get uptime: {e}"))
         {
             data.system.uptime = Some(uptime.as_secs());
-            data.system.boottime = uptime.boot_time().ok();
+            data.system.boot_time = uptime.boot_time().ok();
         }
 
         // setting utsname info

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1405,7 +1405,7 @@ impl EventConsumer<'_> {
         let self_exe = PathBuf::from("/proc/self/exe");
         data.kunai.exe = Hashes::from_path_ref(self_exe.clone().canonicalize().unwrap_or(self_exe));
 
-        data.kunai.config_sha256 = self.config.sha256().ok().unwrap_or("?".into());
+        data.kunai.config.sha256 = self.config.sha256().ok().unwrap_or("?".into());
 
         // setting up uptime and boottime
         if let Ok(uptime) = Uptime::from_sys().inspect_err(|e| error!("failed to get uptime: {e}"))

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -23,6 +23,8 @@ use crate::{
 };
 
 pub mod agent;
+mod start;
+pub use start::*;
 
 #[derive(Debug, Default, Serialize, Deserialize, FieldGetter)]
 pub struct File {
@@ -1071,48 +1073,6 @@ impl IocGetter for FileScanData {
         let mut v = vec![self.path.to_string_lossy()];
         v.extend(self.meta.iocs());
         v
-    }
-}
-
-/// Encodes Kunai related data
-#[derive(Default, Debug, Serialize, Deserialize)]
-pub struct KunaiData {
-    /// Version
-    pub version: String,
-    /// Information about executable
-    pub exe: Hashes,
-    /// Sha256 of the configuration
-    pub config_sha256: String,
-}
-
-/// System related information
-#[derive(Default, Debug, Serialize, Deserialize)]
-pub struct SystemData {
-    /// Uptime in seconds (read from /proc/uptime)
-    pub uptime: Option<f64>,
-    /// Boot time computed from uptime
-    pub boot_time: Option<DateTime<Utc>>,
-    /// Utsname information, except nodename
-    /// which duplicates information in
-    /// .info.host.name
-    pub sysname: String,
-    pub release: String,
-    pub version: String,
-    pub machine: String,
-    pub domainname: String,
-}
-
-/// Structure holding information we want
-/// to display in start events
-#[derive(Default, Debug, Serialize, Deserialize)]
-pub struct StartData {
-    pub kunai: KunaiData,
-    pub system: SystemData,
-}
-
-impl StartData {
-    pub fn new() -> Self {
-        Default::default()
     }
 }
 

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -1074,6 +1074,48 @@ impl IocGetter for FileScanData {
     }
 }
 
+/// Encodes Kunai related data
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct KunaiData {
+    /// Version
+    pub version: String,
+    /// Information about executable
+    pub exe: Hashes,
+    /// Sha256 of the configuration
+    pub config_sha256: String,
+}
+
+/// System related information
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct SystemData {
+    /// Uptime in seconds (read from /proc/uptime)
+    pub uptime: Option<f64>,
+    /// Boottime computed from uptime
+    pub boottime: Option<DateTime<Utc>>,
+    /// Utsname information, except nodename
+    /// which duplicates information in
+    /// .info.host.name
+    pub sysname: String,
+    pub release: String,
+    pub version: String,
+    pub machine: String,
+    pub domainname: String,
+}
+
+/// Structure holding information we want
+/// to display in start events
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct StartData {
+    pub kunai: KunaiData,
+    pub system: SystemData,
+}
+
+impl StartData {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
 #[derive(Default, Debug, Serialize, Deserialize, FieldGetter)]
 pub struct LossData {
     pub read: u64,

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -1090,8 +1090,8 @@ pub struct KunaiData {
 pub struct SystemData {
     /// Uptime in seconds (read from /proc/uptime)
     pub uptime: Option<f64>,
-    /// Boottime computed from uptime
-    pub boottime: Option<DateTime<Utc>>,
+    /// Boot time computed from uptime
+    pub boot_time: Option<DateTime<Utc>>,
     /// Utsname information, except nodename
     /// which duplicates information in
     /// .info.host.name

--- a/kunai/src/events/start.rs
+++ b/kunai/src/events/start.rs
@@ -1,0 +1,52 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::cache::Hashes;
+
+/// System related information
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct SystemData {
+    /// Uptime in seconds (read from /proc/uptime)
+    pub uptime: Option<f64>,
+    /// Boot time computed from uptime
+    pub boot_time: Option<DateTime<Utc>>,
+    /// Utsname information, except nodename
+    /// which duplicates information in
+    /// .info.host.name
+    pub sysname: String,
+    pub release: String,
+    pub version: String,
+    pub machine: String,
+    pub domainname: String,
+}
+
+/// System related information
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct ConfigData {
+    pub sha256: String,
+}
+
+/// Encodes Kunai related data
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct KunaiData {
+    /// Version
+    pub version: String,
+    /// Information about executable
+    pub exe: Hashes,
+    /// Configuration related data
+    pub config: ConfigData,
+}
+
+/// Structure holding information we want
+/// to display in start events
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct StartData {
+    pub system: SystemData,
+    pub kunai: KunaiData,
+}
+
+impl StartData {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}

--- a/kunai/src/util.rs
+++ b/kunai/src/util.rs
@@ -11,6 +11,7 @@ pub mod bpf;
 pub mod elf;
 pub mod namespace;
 pub mod uname;
+pub mod uptime;
 
 #[inline]
 pub fn is_public_ip(ip: IpAddr) -> bool {

--- a/kunai/src/util/uptime.rs
+++ b/kunai/src/util/uptime.rs
@@ -1,0 +1,59 @@
+use std::{
+    fs, io,
+    num::ParseFloatError,
+    time::{Duration, TryFromFloatSecsError},
+};
+
+use chrono::{OutOfRangeError, Utc};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("failed to read uptime")]
+    Read,
+    #[error("parse: {0}")]
+    ParseFloat(#[from] ParseFloatError),
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+    #[error("try_from: {0}")]
+    TryFromFloatSecs(#[from] TryFromFloatSecsError),
+    #[error("oor: {0}")]
+    OutOfRange(#[from] OutOfRangeError),
+    #[error("out of range date computation")]
+    ComputeOutOfRange,
+}
+
+#[derive(Debug)]
+pub struct Uptime(f64, chrono::Duration);
+
+impl Uptime {
+    #[inline]
+    pub fn from_sys() -> Result<Self, Error> {
+        // Read the content of /proc/uptime
+        let uptime_content = fs::read_to_string("/proc/uptime")?;
+
+        // Extract the uptime in seconds
+        let uptime_seconds: f64 = uptime_content
+            .split_whitespace()
+            .next()
+            .ok_or(Error::Read)?
+            .parse()?;
+
+        Ok(Self(
+            uptime_seconds,
+            chrono::Duration::from_std(Duration::try_from_secs_f64(uptime_seconds)?)?,
+        ))
+    }
+
+    #[inline(always)]
+    pub fn as_secs(&self) -> f64 {
+        self.0
+    }
+
+    #[inline(always)]
+    pub fn boot_time(&self) -> Result<chrono::DateTime<Utc>, Error> {
+        Utc::now()
+            .checked_sub_signed(self.1)
+            .ok_or(Error::ComputeOutOfRange)
+    }
+}


### PR DESCRIPTION
This PR introduces a new `start` event containing system and kunai information when the tool is started:

This event can be used (amongst other things) to:
- detect when the service is started / restarted
- track configuration changes
- know from logs the kunai version and cryptographic hash of the binary

fix #9 