### PR TITLE
chore: ebpf toolchain upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,25 +329,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.0",
  "shlex",
  "syn 2.0.90",
- "which",
 ]
 
 [[package]]
@@ -605,7 +602,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "log",
  "regalloc2",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "smallvec",
  "target-lexicon",
 ]
@@ -1497,12 +1494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2205,7 @@ checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
 dependencies = [
  "hashbrown 0.14.3",
  "log",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "slice-group-by",
  "smallvec",
 ]
@@ -2316,9 +2307,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rusticata-macros"
@@ -3465,7 +3456,7 @@ dependencies = [
  "regex-syntax 0.8.4",
  "roxmltree",
  "rsa",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "serde",
  "serde_json",
  "sha1",
@@ -3509,7 +3500,7 @@ dependencies = [
  "logos",
  "num-traits",
  "rowan",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "serde",
  "yansi",
 ]

--- a/kunai-common/Cargo.toml
+++ b/kunai-common/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 user = ["aya", "dns-parser", "uuid", "thiserror", "serde"]
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.71"
 
 [dependencies]
 # optional deps (only for userland)

--- a/kunai-common/src/co_re/gen.rs
+++ b/kunai-common/src/co_re/gen.rs
@@ -36,10 +36,10 @@ pub struct cred {
     pub uid: kuid_t,
     pub gid: kgid_t,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cred_uid(pcred: *mut cred) -> uid_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cred_gid(pcred: *mut cred) -> gid_t;
 }
 #[repr(C)]
@@ -60,40 +60,40 @@ pub struct qstr__bindgen_ty_1__bindgen_ty_1 {
     pub hash: u32_,
     pub len: u32_,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_name(qstr: *mut qstr) -> *const ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_name_user(qstr: *mut qstr) -> *const ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_name_exists(qstr: *mut qstr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_hash_len(qstr: *mut qstr) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_hash_len_user(qstr: *mut qstr) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_hash_len_exists(qstr: *mut qstr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_hash(qstr: *mut qstr) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_hash_user(qstr: *mut qstr) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_hash_exists(qstr: *mut qstr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_len(qstr: *mut qstr) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_len_user(qstr: *mut qstr) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_qstr_len_exists(qstr: *mut qstr) -> bool;
 }
 #[repr(C)]
@@ -101,13 +101,13 @@ extern "C" {
 pub struct vfsmount {
     pub mnt_root: *mut dentry,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_vfsmount_mnt_root(vfsmount: *mut vfsmount) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_vfsmount_mnt_root_user(vfsmount: *mut vfsmount) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_vfsmount_mnt_root_exists(vfsmount: *mut vfsmount) -> bool;
 }
 #[repr(C)]
@@ -118,43 +118,43 @@ pub struct mount {
     pub mnt: vfsmount,
     pub mnt_mp: *mut mountpoint,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_parent(mount: *mut mount) -> *mut mount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_parent_user(mount: *mut mount) -> *mut mount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_parent_exists(mount: *mut mount) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_mountpoint(mount: *mut mount) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_mountpoint_user(mount: *mut mount) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_mountpoint_exists(mount: *mut mount) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt(mount: *mut mount) -> *mut vfsmount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_user(mount: *mut mount) -> *mut vfsmount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_exists(mount: *mut mount) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_mp(mount: *mut mount) -> *mut mountpoint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_mp_user(mount: *mut mount) -> *mut mountpoint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_mnt_mp_exists(mount: *mut mount) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mount_from_vfsmount(vfs: *mut vfsmount) -> *mut mount;
 }
 #[repr(C)]
@@ -162,13 +162,13 @@ extern "C" {
 pub struct super_block {
     pub s_root: *mut dentry,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_super_block_s_root(super_block: *mut super_block) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_super_block_s_root_user(super_block: *mut super_block) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_super_block_s_root_exists(super_block: *mut super_block) -> bool;
 }
 #[repr(C)]
@@ -180,49 +180,49 @@ pub struct dentry {
     pub d_sb: *mut super_block,
     pub d_inode: *mut inode,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_parent(dentry: *mut dentry) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_parent_user(dentry: *mut dentry) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_parent_exists(dentry: *mut dentry) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_flags(dentry: *mut dentry) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_flags_user(dentry: *mut dentry) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_flags_exists(dentry: *mut dentry) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_name(dentry: *mut dentry) -> *mut qstr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_name_user(dentry: *mut dentry) -> *mut qstr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_name_exists(dentry: *mut dentry) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_sb(dentry: *mut dentry) -> *mut super_block;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_sb_user(dentry: *mut dentry) -> *mut super_block;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_sb_exists(dentry: *mut dentry) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_inode(dentry: *mut dentry) -> *mut inode;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_inode_user(dentry: *mut dentry) -> *mut inode;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_dentry_d_inode_exists(dentry: *mut dentry) -> bool;
 }
 #[repr(C)]
@@ -230,13 +230,13 @@ extern "C" {
 pub struct mountpoint {
     pub m_dentry: *mut dentry,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mountpoint_m_dentry(mountpoint: *mut mountpoint) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mountpoint_m_dentry_user(mountpoint: *mut mountpoint) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mountpoint_m_dentry_exists(mountpoint: *mut mountpoint) -> bool;
 }
 #[repr(C)]
@@ -245,22 +245,22 @@ pub struct path {
     pub mnt: *mut vfsmount,
     pub dentry: *mut dentry,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_path_mnt(path: *mut path) -> *mut vfsmount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_path_mnt_user(path: *mut path) -> *mut vfsmount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_path_mnt_exists(path: *mut path) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_path_dentry(path: *mut path) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_path_dentry_user(path: *mut path) -> *mut dentry;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_path_dentry_exists(path: *mut path) -> bool;
 }
 pub type time64_t = __s64;
@@ -301,94 +301,94 @@ pub union inode__bindgen_ty_3 {
     pub i_ctime: timespec64,
     pub __i_ctime: timespec64,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_ino(inode: *mut inode) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_ino_user(inode: *mut inode) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_ino_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_mode(inode: *mut inode) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_mode_user(inode: *mut inode) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_mode_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_sb(inode: *mut inode) -> *mut super_block;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_sb_user(inode: *mut inode) -> *mut super_block;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_sb_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_size(inode: *mut inode) -> ::core::ffi::c_longlong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_size_user(inode: *mut inode) -> ::core::ffi::c_longlong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_size_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_atime(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_atime_user(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_atime_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_atime(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_atime_user(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_atime_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_mtime(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_mtime_user(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_mtime_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_mtime(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_mtime_user(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_mtime_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_ctime(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_ctime_user(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode_i_ctime_exists(inode: *mut inode) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_ctime(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_ctime_user(inode: *mut inode) -> timespec64;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_inode___i_ctime_exists(inode: *mut inode) -> bool;
 }
 #[repr(C)]
@@ -400,49 +400,49 @@ pub struct file {
     pub f_flags: ::core::ffi::c_uint,
     pub f_mode: ::core::ffi::c_uint,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_path(file: *mut file) -> *mut path;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_path_user(file: *mut file) -> *mut path;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_path_exists(file: *mut file) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_inode(file: *mut file) -> *mut inode;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_inode_user(file: *mut file) -> *mut inode;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_inode_exists(file: *mut file) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_private_data(file: *mut file) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_private_data_user(file: *mut file) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_private_data_exists(file: *mut file) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_flags(file: *mut file) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_flags_user(file: *mut file) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_flags_exists(file: *mut file) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_mode(file: *mut file) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_mode_user(file: *mut file) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_file_f_mode_exists(file: *mut file) -> bool;
 }
 #[repr(C)]
@@ -451,22 +451,22 @@ pub struct fd {
     pub file: *mut file,
     pub flags: ::core::ffi::c_uint,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fd_file(fd: *mut fd) -> *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fd_file_user(fd: *mut fd) -> *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fd_file_exists(fd: *mut fd) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fd_flags(fd: *mut fd) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fd_flags_user(fd: *mut fd) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fd_flags_exists(fd: *mut fd) -> bool;
 }
 #[repr(C)]
@@ -476,31 +476,31 @@ pub struct mm_struct {
     pub arg_end: ::core::ffi::c_ulong,
     pub exe_file: *mut file,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_arg_start(mm_struct: *mut mm_struct) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_arg_start_user(mm_struct: *mut mm_struct) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_arg_start_exists(mm_struct: *mut mm_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_arg_end(mm_struct: *mut mm_struct) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_arg_end_user(mm_struct: *mut mm_struct) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_arg_end_exists(mm_struct: *mut mm_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_exe_file(mm_struct: *mut mm_struct) -> *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_exe_file_user(mm_struct: *mut mm_struct) -> *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mm_struct_exe_file_exists(mm_struct: *mut mm_struct) -> bool;
 }
 #[repr(C)]
@@ -508,13 +508,13 @@ extern "C" {
 pub struct ns_common {
     pub inum: ::core::ffi::c_uint,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_ns_common_inum(ns_common: *mut ns_common) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_ns_common_inum_user(ns_common: *mut ns_common) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_ns_common_inum_exists(ns_common: *mut ns_common) -> bool;
 }
 #[repr(C)]
@@ -524,32 +524,32 @@ pub struct mnt_namespace {
     pub root: *mut mount,
     pub mounts: ::core::ffi::c_uint,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_ns(mnt_namespace: *mut mnt_namespace) -> *mut ns_common;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_ns_user(mnt_namespace: *mut mnt_namespace) -> *mut ns_common;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_ns_exists(mnt_namespace: *mut mnt_namespace) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_root(mnt_namespace: *mut mnt_namespace) -> *mut mount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_root_user(mnt_namespace: *mut mnt_namespace) -> *mut mount;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_root_exists(mnt_namespace: *mut mnt_namespace) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_mounts(mnt_namespace: *mut mnt_namespace) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_mounts_user(mnt_namespace: *mut mnt_namespace)
         -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_mnt_namespace_mounts_exists(mnt_namespace: *mut mnt_namespace) -> bool;
 }
 #[repr(C)]
@@ -562,66 +562,66 @@ pub struct new_utsname {
     pub machine: [::core::ffi::c_char; 65usize],
     pub domainname: [::core::ffi::c_char; 65usize],
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_sysname(new_utsname: *mut new_utsname) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_sysname_user(new_utsname: *mut new_utsname)
         -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_sysname_exists(new_utsname: *mut new_utsname) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_nodename(new_utsname: *mut new_utsname) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_nodename_user(
         new_utsname: *mut new_utsname,
     ) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_nodename_exists(new_utsname: *mut new_utsname) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_release(new_utsname: *mut new_utsname) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_release_user(new_utsname: *mut new_utsname)
         -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_release_exists(new_utsname: *mut new_utsname) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_version(new_utsname: *mut new_utsname) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_version_user(new_utsname: *mut new_utsname)
         -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_version_exists(new_utsname: *mut new_utsname) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_machine(new_utsname: *mut new_utsname) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_machine_user(new_utsname: *mut new_utsname)
         -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_machine_exists(new_utsname: *mut new_utsname) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_domainname(new_utsname: *mut new_utsname) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_domainname_user(
         new_utsname: *mut new_utsname,
     ) -> *mut ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_new_utsname_domainname_exists(new_utsname: *mut new_utsname) -> bool;
 }
 #[repr(C)]
@@ -630,22 +630,22 @@ pub struct uts_namespace {
     pub name: new_utsname,
     pub ns: ns_common,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_uts_namespace_ns(uts_namespace: *mut uts_namespace) -> *mut ns_common;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_uts_namespace_ns_user(uts_namespace: *mut uts_namespace) -> *mut ns_common;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_uts_namespace_ns_exists(uts_namespace: *mut uts_namespace) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_uts_namespace_name(uts_namespace: *mut uts_namespace) -> *mut new_utsname;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_uts_namespace_name_user(uts_namespace: *mut uts_namespace) -> *mut new_utsname;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_uts_namespace_name_exists(uts_namespace: *mut uts_namespace) -> bool;
 }
 #[repr(C)]
@@ -654,22 +654,22 @@ pub struct nsproxy {
     pub mnt_ns: *mut mnt_namespace,
     pub uts_ns: *mut uts_namespace,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_nsproxy_mnt_ns(nsproxy: *mut nsproxy) -> *mut mnt_namespace;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_nsproxy_mnt_ns_user(nsproxy: *mut nsproxy) -> *mut mnt_namespace;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_nsproxy_mnt_ns_exists(nsproxy: *mut nsproxy) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_nsproxy_uts_ns(nsproxy: *mut nsproxy) -> *mut uts_namespace;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_nsproxy_uts_ns_user(nsproxy: *mut nsproxy) -> *mut uts_namespace;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_nsproxy_uts_ns_exists(nsproxy: *mut nsproxy) -> bool;
 }
 #[repr(C)]
@@ -678,22 +678,22 @@ pub struct kernfs_node {
     pub parent: *mut kernfs_node,
     pub name: *const ::core::ffi::c_char,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernfs_node_parent(kernfs_node: *mut kernfs_node) -> *mut kernfs_node;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernfs_node_parent_user(kernfs_node: *mut kernfs_node) -> *mut kernfs_node;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernfs_node_parent_exists(kernfs_node: *mut kernfs_node) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernfs_node_name(kernfs_node: *mut kernfs_node) -> *const ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernfs_node_name_user(kernfs_node: *mut kernfs_node) -> *const ::core::ffi::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernfs_node_name_exists(kernfs_node: *mut kernfs_node) -> bool;
 }
 #[repr(C)]
@@ -701,13 +701,13 @@ extern "C" {
 pub struct cgroup {
     pub kn: *mut kernfs_node,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cgroup_kn(cgroup: *mut cgroup) -> *mut kernfs_node;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cgroup_kn_user(cgroup: *mut cgroup) -> *mut kernfs_node;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cgroup_kn_exists(cgroup: *mut cgroup) -> bool;
 }
 #[repr(C)]
@@ -715,17 +715,17 @@ extern "C" {
 pub struct cgroup_subsys_state {
     pub cgroup: *mut cgroup,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cgroup_subsys_state_cgroup(
         cgroup_subsys_state: *mut cgroup_subsys_state,
     ) -> *mut cgroup;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cgroup_subsys_state_cgroup_user(
         cgroup_subsys_state: *mut cgroup_subsys_state,
     ) -> *mut cgroup;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_cgroup_subsys_state_cgroup_exists(
         cgroup_subsys_state: *mut cgroup_subsys_state,
     ) -> bool;
@@ -735,13 +735,13 @@ extern "C" {
 pub struct task_group {
     pub css: cgroup_subsys_state,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_group_css(task_group: *mut task_group) -> *mut cgroup_subsys_state;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_group_css_user(task_group: *mut task_group) -> *mut cgroup_subsys_state;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_group_css_exists(task_group: *mut task_group) -> bool;
 }
 #[repr(C)]
@@ -750,22 +750,22 @@ pub struct fdtable {
     pub max_fds: ::core::ffi::c_uint,
     pub fd: *mut *mut file,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fdtable_max_fds(fdtable: *mut fdtable) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fdtable_max_fds_user(fdtable: *mut fdtable) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fdtable_max_fds_exists(fdtable: *mut fdtable) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fdtable_fd(fdtable: *mut fdtable) -> *mut *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fdtable_fd_user(fdtable: *mut fdtable) -> *mut *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_fdtable_fd_exists(fdtable: *mut fdtable) -> bool;
 }
 #[repr(C)]
@@ -774,22 +774,22 @@ pub struct files_struct {
     pub fdt: *mut fdtable,
     pub fd_array: [*mut file; 1usize],
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_files_struct_fd_array(files_struct: *mut files_struct) -> *mut *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_files_struct_fd_array_user(files_struct: *mut files_struct) -> *mut *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_files_struct_fd_array_exists(files_struct: *mut files_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_files_struct_fdt(files_struct: *mut files_struct) -> *mut fdtable;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_files_struct_fdt_user(files_struct: *mut files_struct) -> *mut fdtable;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_files_struct_fdt_exists(files_struct: *mut files_struct) -> bool;
 }
 #[repr(C)]
@@ -815,141 +815,141 @@ pub union task_struct__bindgen_ty_1 {
     pub start_boottime: __u64,
     pub real_start_time: __u64,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_flags(task_struct: *mut task_struct) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_flags_user(task_struct: *mut task_struct) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_flags_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_start_time(task_struct: *mut task_struct) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_start_time_user(
         task_struct: *mut task_struct,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_start_time_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_start_boottime(
         task_struct: *mut task_struct,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_start_boottime_user(
         task_struct: *mut task_struct,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_start_boottime_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_real_start_time(
         task_struct: *mut task_struct,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_real_start_time_user(
         task_struct: *mut task_struct,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_real_start_time_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_comm(task_struct: *mut task_struct) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_comm_user(task_struct: *mut task_struct) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_comm_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_pid(task_struct: *mut task_struct) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_pid_user(task_struct: *mut task_struct) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_pid_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_tgid(task_struct: *mut task_struct) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_tgid_user(task_struct: *mut task_struct) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_tgid_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_cred(task_struct: *mut task_struct) -> *mut cred;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_cred_user(task_struct: *mut task_struct) -> *mut cred;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_cred_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_group_leader(task_struct: *mut task_struct) -> *mut task_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_group_leader_user(task_struct: *mut task_struct) -> *mut task_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_group_leader_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_real_parent(task_struct: *mut task_struct) -> *mut task_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_real_parent_user(task_struct: *mut task_struct) -> *mut task_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_real_parent_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_mm(task_struct: *mut task_struct) -> *mut mm_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_mm_user(task_struct: *mut task_struct) -> *mut mm_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_mm_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_files(task_struct: *mut task_struct) -> *mut files_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_files_user(task_struct: *mut task_struct) -> *mut files_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_files_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_nsproxy(task_struct: *mut task_struct) -> *mut nsproxy;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_nsproxy_user(task_struct: *mut task_struct) -> *mut nsproxy;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_nsproxy_exists(task_struct: *mut task_struct) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_sched_task_group(task_struct: *mut task_struct) -> *mut task_group;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_sched_task_group_user(task_struct: *mut task_struct)
         -> *mut task_group;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_task_struct_sched_task_group_exists(task_struct: *mut task_struct) -> bool;
 }
 #[repr(C)]
@@ -957,13 +957,13 @@ extern "C" {
 pub struct bpf_ksym {
     pub name: [::core::ffi::c_uchar; 512usize],
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_ksym_name(bpf_ksym: *mut bpf_ksym) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_ksym_name_user(bpf_ksym: *mut bpf_ksym) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_ksym_name_exists(bpf_ksym: *mut bpf_ksym) -> bool;
 }
 #[repr(C)]
@@ -975,58 +975,58 @@ pub struct bpf_prog_aux {
     pub verified_insns: __u32,
     pub ksym: bpf_ksym,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_id(bpf_prog_aux: *mut bpf_prog_aux) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_id_user(bpf_prog_aux: *mut bpf_prog_aux) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_id_exists(bpf_prog_aux: *mut bpf_prog_aux) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_name(bpf_prog_aux: *mut bpf_prog_aux) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_name_user(
         bpf_prog_aux: *mut bpf_prog_aux,
     ) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_name_exists(bpf_prog_aux: *mut bpf_prog_aux) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_attach_func_name(
         bpf_prog_aux: *mut bpf_prog_aux,
     ) -> *const ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_attach_func_name_user(
         bpf_prog_aux: *mut bpf_prog_aux,
     ) -> *const ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_attach_func_name_exists(bpf_prog_aux: *mut bpf_prog_aux) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_verified_insns(bpf_prog_aux: *mut bpf_prog_aux)
         -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_verified_insns_user(
         bpf_prog_aux: *mut bpf_prog_aux,
     ) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_verified_insns_exists(bpf_prog_aux: *mut bpf_prog_aux) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_ksym(bpf_prog_aux: *mut bpf_prog_aux) -> *mut bpf_ksym;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_ksym_user(bpf_prog_aux: *mut bpf_prog_aux) -> *mut bpf_ksym;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_ksym_exists(bpf_prog_aux: *mut bpf_prog_aux) -> bool;
 }
 pub const bpf_prog_type_PROG_TYPE: bpf_prog_type = 0;
@@ -1043,58 +1043,58 @@ pub struct bpf_prog {
     pub aux: *mut bpf_prog_aux,
     pub orig_prog: *mut sock_fprog_kern,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux(bpf_prog: *mut bpf_prog) -> *mut bpf_prog_aux;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_user(bpf_prog: *mut bpf_prog) -> *mut bpf_prog_aux;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_aux_exists(bpf_prog: *mut bpf_prog) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_orig_prog(bpf_prog: *mut bpf_prog) -> *mut sock_fprog_kern;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_orig_prog_user(bpf_prog: *mut bpf_prog) -> *mut sock_fprog_kern;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_orig_prog_exists(bpf_prog: *mut bpf_prog) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_tag(bpf_prog: *mut bpf_prog) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_tag_user(bpf_prog: *mut bpf_prog) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_tag_exists(bpf_prog: *mut bpf_prog) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_type(bpf_prog: *mut bpf_prog) -> bpf_prog_type;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_type_user(bpf_prog: *mut bpf_prog) -> bpf_prog_type;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_type_exists(bpf_prog: *mut bpf_prog) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_expected_attach_type(bpf_prog: *mut bpf_prog) -> bpf_attach_type;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_expected_attach_type_user(bpf_prog: *mut bpf_prog) -> bpf_attach_type;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_expected_attach_type_exists(bpf_prog: *mut bpf_prog) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_len(bpf_prog: *mut bpf_prog) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_len_user(bpf_prog: *mut bpf_prog) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bpf_prog_len_exists(bpf_prog: *mut bpf_prog) -> bool;
 }
 #[repr(C)]
@@ -1105,40 +1105,40 @@ pub struct sock_filter {
     pub jf: __u8,
     pub k: __u32,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_code(sock_filter: *mut sock_filter) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_code_user(sock_filter: *mut sock_filter) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_code_exists(sock_filter: *mut sock_filter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_jt(sock_filter: *mut sock_filter) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_jt_user(sock_filter: *mut sock_filter) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_jt_exists(sock_filter: *mut sock_filter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_jf(sock_filter: *mut sock_filter) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_jf_user(sock_filter: *mut sock_filter) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_jf_exists(sock_filter: *mut sock_filter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_k(sock_filter: *mut sock_filter) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_k_user(sock_filter: *mut sock_filter) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_filter_k_exists(sock_filter: *mut sock_filter) -> bool;
 }
 #[repr(C)]
@@ -1147,22 +1147,22 @@ pub struct sock_fprog {
     pub len: ::core::ffi::c_ushort,
     pub filter: *mut sock_filter,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_len(sock_fprog: *mut sock_fprog) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_len_user(sock_fprog: *mut sock_fprog) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_len_exists(sock_fprog: *mut sock_fprog) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_filter(sock_fprog: *mut sock_fprog) -> *mut sock_filter;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_filter_user(sock_fprog: *mut sock_fprog) -> *mut sock_filter;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_filter_exists(sock_fprog: *mut sock_fprog) -> bool;
 }
 #[repr(C)]
@@ -1171,27 +1171,27 @@ pub struct sock_fprog_kern {
     pub len: u16_,
     pub filter: *mut sock_filter,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_kern_len(sock_fprog_kern: *mut sock_fprog_kern)
         -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_kern_len_user(
         sock_fprog_kern: *mut sock_fprog_kern,
     ) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_kern_len_exists(sock_fprog_kern: *mut sock_fprog_kern) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_kern_filter(sock_fprog_kern: *mut sock_fprog_kern) -> *mut sock_filter;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_kern_filter_user(
         sock_fprog_kern: *mut sock_fprog_kern,
     ) -> *mut sock_filter;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_fprog_kern_filter_exists(sock_fprog_kern: *mut sock_fprog_kern) -> bool;
 }
 #[repr(C)]
@@ -1201,31 +1201,31 @@ pub struct linux_binprm {
     pub file: *mut file,
     pub cred: *mut cred,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_mm(linux_binprm: *mut linux_binprm) -> *mut mm_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_mm_user(linux_binprm: *mut linux_binprm) -> *mut mm_struct;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_mm_exists(linux_binprm: *mut linux_binprm) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_file(linux_binprm: *mut linux_binprm) -> *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_file_user(linux_binprm: *mut linux_binprm) -> *mut file;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_file_exists(linux_binprm: *mut linux_binprm) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_cred(linux_binprm: *mut linux_binprm) -> *mut cred;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_cred_user(linux_binprm: *mut linux_binprm) -> *mut cred;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_linux_binprm_cred_exists(linux_binprm: *mut linux_binprm) -> bool;
 }
 #[repr(C)]
@@ -1233,13 +1233,13 @@ extern "C" {
 pub struct load_info {
     pub name: *const ::core::ffi::c_uchar,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_load_info_name(load_info: *mut load_info) -> *const ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_load_info_name_user(load_info: *mut load_info) -> *const ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_load_info_name_exists(load_info: *mut load_info) -> bool;
 }
 pub type __addrpair = __u64;
@@ -1256,13 +1256,13 @@ pub union in6_addr__bindgen_ty_1 {
     pub u6_addr16: [__be16; 8usize],
     pub u6_addr32: [__be32; 4usize],
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_in6_addr_u6_addr8(in6_addr: *mut in6_addr) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_in6_addr_u6_addr8_user(in6_addr: *mut in6_addr) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_in6_addr_u6_addr8_exists(in6_addr: *mut in6_addr) -> bool;
 }
 pub type sa_family_t = __kernel_sa_family_t;
@@ -1271,13 +1271,13 @@ pub type sa_family_t = __kernel_sa_family_t;
 pub struct sockaddr {
     pub sa_family: sa_family_t,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_sa_family(sockaddr: *mut sockaddr) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_sa_family_user(sockaddr: *mut sockaddr) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_sa_family_exists(sockaddr: *mut sockaddr) -> bool;
 }
 #[repr(C)]
@@ -1293,32 +1293,32 @@ pub struct sockaddr_in {
     pub sin_addr: in_addr,
     pub __pad: [::core::ffi::c_uchar; 8usize],
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_sin_family(sockaddr_in: *mut sockaddr_in) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_sin_family_user(sockaddr_in: *mut sockaddr_in)
         -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_sin_family_exists(sockaddr_in: *mut sockaddr_in) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_sin_port(sockaddr_in: *mut sockaddr_in) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_sin_port_user(sockaddr_in: *mut sockaddr_in) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_sin_port_exists(sockaddr_in: *mut sockaddr_in) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_s_addr(sockaddr_in: *mut sockaddr_in) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_s_addr_user(sockaddr_in: *mut sockaddr_in) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in_s_addr_exists(sockaddr_in: *mut sockaddr_in) -> bool;
 }
 #[repr(C)]
@@ -1330,35 +1330,35 @@ pub struct sockaddr_in6 {
     pub sin6_addr: in6_addr,
     pub sin6_scope_id: __u32,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_family(sockaddr_in6: *mut sockaddr_in6) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_family_user(
         sockaddr_in6: *mut sockaddr_in6,
     ) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_family_exists(sockaddr_in6: *mut sockaddr_in6) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_port(sockaddr_in6: *mut sockaddr_in6) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_port_user(
         sockaddr_in6: *mut sockaddr_in6,
     ) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_port_exists(sockaddr_in6: *mut sockaddr_in6) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_addr(sockaddr_in6: *mut sockaddr_in6) -> *mut in6_addr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_addr_user(sockaddr_in6: *mut sockaddr_in6) -> *mut in6_addr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sockaddr_in6_sin6_addr_exists(sockaddr_in6: *mut sockaddr_in6) -> bool;
 }
 #[repr(C)]
@@ -1380,54 +1380,54 @@ pub union sock_common__bindgen_ty_1 {
 pub union sock_common__bindgen_ty_2 {
     pub skc_portpair: __portpair,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_family(sock_common: *mut sock_common) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_family_user(sock_common: *mut sock_common)
         -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_family_exists(sock_common: *mut sock_common) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_addrpair(sock_common: *mut sock_common)
         -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_addrpair_user(
         sock_common: *mut sock_common,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_addrpair_exists(sock_common: *mut sock_common) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_portpair(sock_common: *mut sock_common) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_portpair_user(sock_common: *mut sock_common)
         -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_portpair_exists(sock_common: *mut sock_common) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_v6_daddr(sock_common: *mut sock_common) -> *mut in6_addr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_v6_daddr_user(sock_common: *mut sock_common) -> *mut in6_addr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_v6_daddr_exists(sock_common: *mut sock_common) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_v6_rcv_saddr(sock_common: *mut sock_common) -> *mut in6_addr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_v6_rcv_saddr_user(sock_common: *mut sock_common) -> *mut in6_addr;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_common_skc_v6_rcv_saddr_exists(sock_common: *mut sock_common) -> bool;
 }
 #[repr(C)]
@@ -1436,22 +1436,22 @@ pub struct sk_buff {
     pub len: ::core::ffi::c_uint,
     pub data: *mut ::core::ffi::c_uchar,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_len(sk_buff: *mut sk_buff) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_len_user(sk_buff: *mut sk_buff) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_len_exists(sk_buff: *mut sk_buff) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_data(sk_buff: *mut sk_buff) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_data_user(sk_buff: *mut sk_buff) -> *mut ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_data_exists(sk_buff: *mut sk_buff) -> bool;
 }
 #[repr(C)]
@@ -1460,22 +1460,22 @@ pub struct sk_buff_list {
     pub next: *mut sk_buff,
     pub prev: *mut sk_buff,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_list_next(sk_buff_list: *mut sk_buff_list) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_list_next_user(sk_buff_list: *mut sk_buff_list) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_list_next_exists(sk_buff_list: *mut sk_buff_list) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_list_prev(sk_buff_list: *mut sk_buff_list) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_list_prev_user(sk_buff_list: *mut sk_buff_list) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_list_prev_exists(sk_buff_list: *mut sk_buff_list) -> bool;
 }
 #[repr(C)]
@@ -1486,40 +1486,40 @@ pub struct sk_buff_head {
     pub list: sk_buff_list,
     pub qlen: __u32,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_next(sk_buff_head: *mut sk_buff_head) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_next_user(sk_buff_head: *mut sk_buff_head) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_next_exists(sk_buff_head: *mut sk_buff_head) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_prev(sk_buff_head: *mut sk_buff_head) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_prev_user(sk_buff_head: *mut sk_buff_head) -> *mut sk_buff;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_prev_exists(sk_buff_head: *mut sk_buff_head) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_list(sk_buff_head: *mut sk_buff_head) -> *mut sk_buff_list;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_list_user(sk_buff_head: *mut sk_buff_head) -> *mut sk_buff_list;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_list_exists(sk_buff_head: *mut sk_buff_head) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_qlen(sk_buff_head: *mut sk_buff_head) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_qlen_user(sk_buff_head: *mut sk_buff_head) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sk_buff_head_qlen_exists(sk_buff_head: *mut sk_buff_head) -> bool;
 }
 #[repr(C)]
@@ -1535,45 +1535,45 @@ pub struct sock {
 pub struct sock___pre_5_6 {
     pub sk_protocol: __u8,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock___pre_5_6_sk_protocol(
         sock___pre_5_6: *mut sock___pre_5_6,
     ) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock___pre_5_6_sk_protocol_exists(sock___pre_5_6: *mut sock___pre_5_6) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock___sk_common(sock: *mut sock) -> *mut sock_common;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock___sk_common_user(sock: *mut sock) -> *mut sock_common;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock___sk_common_exists(sock: *mut sock) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_protocol(sock: *mut sock) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_protocol_user(sock: *mut sock) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_protocol_exists(sock: *mut sock) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_type(sock: *mut sock) -> ::core::ffi::c_ushort;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_type_exists(sock: *mut sock) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_receive_queue(sock: *mut sock) -> *mut sk_buff_head;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_receive_queue_user(sock: *mut sock) -> *mut sk_buff_head;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_sock_sk_receive_queue_exists(sock: *mut sock) -> bool;
 }
 #[repr(C)]
@@ -1581,13 +1581,13 @@ extern "C" {
 pub struct socket {
     pub sk: *mut sock,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_socket_sk(socket: *mut socket) -> *mut sock;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_socket_sk_user(socket: *mut socket) -> *mut sock;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_socket_sk_exists(socket: *mut socket) -> bool;
 }
 #[repr(C)]
@@ -1596,64 +1596,64 @@ pub struct iovec {
     pub iov_base: *mut ::core::ffi::c_void,
     pub iov_len: __kernel_size_t,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iovec_iov_base(iovec: *mut iovec) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iovec_iov_base_user(iovec: *mut iovec) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iovec_iov_base_exists(iovec: *mut iovec) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iovec_iov_len(iovec: *mut iovec) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iovec_iov_len_user(iovec: *mut iovec) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iovec_iov_len_exists(iovec: *mut iovec) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_IOVEC() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_IOVEC_exists() -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_KVEC() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_KVEC_exists() -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_BVEC() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_BVEC_exists() -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_PIPE() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_PIPE_exists() -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_XARRAY() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_XARRAY_exists() -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_DISCARD() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_DISCARD_exists() -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_UBUF() -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iter_type_ITER_UBUF_exists() -> bool;
 }
 #[repr(C)]
@@ -1668,31 +1668,31 @@ pub struct bio_vec {
     pub bv_len: ::core::ffi::c_uint,
     pub bv_offset: ::core::ffi::c_uint,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_page(bio_vec: *mut bio_vec) -> *mut page;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_page_user(bio_vec: *mut bio_vec) -> *mut page;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_page_exists(bio_vec: *mut bio_vec) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_len(bio_vec: *mut bio_vec) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_len_user(bio_vec: *mut bio_vec) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_len_exists(bio_vec: *mut bio_vec) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_offset(bio_vec: *mut bio_vec) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_offset_user(bio_vec: *mut bio_vec) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_bio_vec_bv_offset_exists(bio_vec: *mut bio_vec) -> bool;
 }
 #[repr(C)]
@@ -1722,76 +1722,76 @@ pub union iov_iter__bindgen_ty_2 {
 pub union iov_iter__bindgen_ty_3 {
     pub nr_segs: ::core::ffi::c_ulong,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_iter_type(iov_iter: *mut iov_iter) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_iter_type_user(iov_iter: *mut iov_iter) -> ::core::ffi::c_uchar;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_iter_type_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_type(iov_iter: *mut iov_iter) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_type_user(iov_iter: *mut iov_iter) -> ::core::ffi::c_uint;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_type_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_count(iov_iter: *mut iov_iter) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_count_user(iov_iter: *mut iov_iter) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_count_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_nr_segs(iov_iter: *mut iov_iter) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_nr_segs_user(iov_iter: *mut iov_iter) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_nr_segs_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_ubuf(iov_iter: *mut iov_iter) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_ubuf_user(iov_iter: *mut iov_iter) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_ubuf_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_iov(iov_iter: *mut iov_iter) -> *mut iovec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_iov_user(iov_iter: *mut iov_iter) -> *mut iovec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_iov_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter___iov(iov_iter: *mut iov_iter) -> *mut iovec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter___iov_user(iov_iter: *mut iov_iter) -> *mut iovec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter___iov_exists(iov_iter: *mut iov_iter) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_bvec(iov_iter: *mut iov_iter) -> *mut bio_vec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_bvec_user(iov_iter: *mut iov_iter) -> *mut bio_vec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_iov_iter_bvec_exists(iov_iter: *mut iov_iter) -> bool;
 }
 #[repr(C)]
@@ -1801,31 +1801,31 @@ pub struct msghdr {
     pub msg_namelen: ::core::ffi::c_int,
     pub msg_iter: iov_iter,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_name(msghdr: *mut msghdr) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_name_user(msghdr: *mut msghdr) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_name_exists(msghdr: *mut msghdr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_namelen(msghdr: *mut msghdr) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_namelen_user(msghdr: *mut msghdr) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_namelen_exists(msghdr: *mut msghdr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_iter(msghdr: *mut msghdr) -> *mut iov_iter;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_iter_user(msghdr: *mut msghdr) -> *mut iov_iter;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_msghdr_msg_iter_exists(msghdr: *mut msghdr) -> bool;
 }
 #[repr(C)]
@@ -1836,42 +1836,42 @@ pub struct user_msghdr {
     pub msg_iov: *mut iovec,
     pub msg_iovlen: __kernel_size_t,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_name(user_msghdr: *mut user_msghdr) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_name_user(
         user_msghdr: *mut user_msghdr,
     ) -> *mut ::core::ffi::c_void;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_name_exists(user_msghdr: *mut user_msghdr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_namelen(user_msghdr: *mut user_msghdr) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_namelen_user(user_msghdr: *mut user_msghdr) -> ::core::ffi::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_namelen_exists(user_msghdr: *mut user_msghdr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_iov(user_msghdr: *mut user_msghdr) -> *mut iovec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_iov_user(user_msghdr: *mut user_msghdr) -> *mut iovec;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_iov_exists(user_msghdr: *mut user_msghdr) -> bool;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_iovlen(user_msghdr: *mut user_msghdr) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_iovlen_user(user_msghdr: *mut user_msghdr) -> ::core::ffi::c_ulong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_user_msghdr_msg_iovlen_exists(user_msghdr: *mut user_msghdr) -> bool;
 }
 #[repr(C)]
@@ -1879,16 +1879,16 @@ extern "C" {
 pub struct kernel_clone_args {
     pub flags: u64_,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernel_clone_args_flags(
         kernel_clone_args: *mut kernel_clone_args,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernel_clone_args_flags_user(
         kernel_clone_args: *mut kernel_clone_args,
     ) -> ::core::ffi::c_ulonglong;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shim_kernel_clone_args_flags_exists(kernel_clone_args: *mut kernel_clone_args) -> bool;
 }

--- a/kunai-common/src/lib.rs
+++ b/kunai-common/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(unused_imports)]
 #![cfg_attr(target_arch = "bpf", no_std)]
+#![cfg_attr(target_arch = "bpf", allow(static_mut_refs))]
 
 use macros::bpf_target_code;
 

--- a/kunai-ebpf/rust-toolchain.toml
+++ b/kunai-ebpf/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-07-07"
+channel = "nightly-2025-01-16"
 
 # The source code of rustc, provided by the rust-src component, is needed for
 # building eBPF programs.

--- a/kunai-ebpf/src/main.rs
+++ b/kunai-ebpf/src/main.rs
@@ -1,4 +1,5 @@
 #![deny(unused_imports)]
+#![allow(static_mut_refs)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
Rust toolchain upgrade and fixes.
This upgrade caused one probe to fail (probably due to new compilation/optimization decisions). So we needed to change a bit the logic of `iov` and `biovec` reading.