### PR TITLE
refactor(ebpf): replace fn calls by clamp

### DIFF
--- a/kunai-common/src/path.rs
+++ b/kunai-common/src/path.rs
@@ -1,9 +1,6 @@
-use crate::{
-    errors::ProbeError, macros::bpf_target_code, macros::not_bpf_target_code, utils::cap_size,
-};
+use crate::{errors::ProbeError, macros::bpf_target_code, macros::not_bpf_target_code};
 
 use super::time::Time;
-use super::utils::bound_value_for_verifier;
 
 use kunai_macros::BpfError;
 
@@ -318,12 +315,11 @@ impl Path {
     pub fn as_slice(&self) -> &[u8] {
         match self.mode {
             Mode::Append => {
-                let len =
-                    bound_value_for_verifier(self.len as isize, 0, self.buffer.len() as isize);
-                &self.buffer[..len as usize]
+                let len = (self.len as usize).clamp(0, self.buffer.len());
+                &self.buffer[..len]
             }
             Mode::Prepend => {
-                let len = cap_size(self.len(), MAX_PATH_LEN - 255);
+                let len = self.len().clamp(0, MAX_PATH_LEN - 255);
                 &self.buffer[(self.buffer.len() - len)..]
             }
         }

--- a/kunai-common/src/string.rs
+++ b/kunai-common/src/string.rs
@@ -1,7 +1,4 @@
-use crate::{
-    errors::ProbeError, macros::bpf_target_code, macros::not_bpf_target_code,
-    utils::bound_value_for_verifier,
-};
+use crate::{errors::ProbeError, macros::bpf_target_code, macros::not_bpf_target_code};
 use core::mem;
 use kunai_macros::BpfError;
 
@@ -107,9 +104,11 @@ impl<const N: usize> String<N> {
         if self.is_full() {
             return Err(Error::StringIsFull);
         }
-        let k = bound_value_for_verifier(at as isize, 0, (self.cap() - 1) as isize);
-        self.s.as_mut()[k as usize] = b;
-        self.len += 1;
+        if let Some(at) = self.s.get_mut(at) {
+            *at = b;
+            self.len += 1;
+        }
+
         Ok(())
     }
 

--- a/kunai-common/src/utils.rs
+++ b/kunai-common/src/utils.rs
@@ -1,69 +1,6 @@
-use core::ops::Rem;
-
 use crate::macros::bpf_target_code;
 
 bpf_target_code! {
     mod bpf;
     pub use bpf::*;
-}
-
-#[inline(always)]
-#[allow(unused_variables)]
-pub fn bound_value_for_verifier(v: isize, min: isize, max: isize) -> isize {
-    #[cfg(target_arch = "bpf")]
-    {
-        if v < min {
-            return min;
-        }
-        if v > max {
-            return max;
-        }
-    }
-    v
-}
-
-// This function must be used to limit the size of a bpf_probe_read call
-// it seems to be a generic enough solution that meet the requirements
-// the verifier expects to be happy
-#[inline(always)]
-#[allow(unused_variables)]
-#[allow(unused_mut)]
-#[allow(unused_assignments)]
-#[allow(clippy::let_and_return)]
-pub fn cap_size<T: Copy + PartialOrd + Rem<Output = T>>(size: T, cap: T) -> T {
-    let mut ret = size;
-    #[cfg(target_arch = "bpf")]
-    {
-        if size >= cap {
-            return cap;
-        }
-        ret = size % cap;
-    }
-    ret
-}
-
-mod test {
-
-    #[test]
-    #[allow(unused_variables)]
-    fn test_stringify_in_macro() {
-        #[derive(Default)]
-        #[allow(dead_code)]
-        struct Dummy {
-            a: u32,
-            b: u64,
-        }
-
-        macro_rules! test_stringify {
-            ($struc:expr, $field:ident) => {
-                println!(stringify!($struc.$field));
-            };
-        }
-
-        let d = Dummy {
-            ..Default::default()
-        };
-
-        test_stringify!(d, a);
-    }
 }


### PR DESCRIPTION
replace `bound_value_for_verifier` and `cap_size` functions by `clamp` methods