### PR TITLE
create: xlaunch cross arch xtask launcher

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,11 @@
 [build]
 # make final binary statically linked against libc
 rustflags = ["-Ctarget-feature=+crt-static"]
-target = ["x86_64-unknown-linux-gnu", "bpfel-unknown-none"]
 
 [alias]
-# replace with the target triple you are developing on must be the same as
-# as the other target than bpf specified in build.target
-xtask = "run -q --target=x86_64-unknown-linux-gnu --package xtask --release --"
+# xlaunch is a cross platform xtask launcher this way we don't
+# have to hardcode target in this alias
+xtask = "run -q --package xlaunch --release --"
 xrun = "xtask run"
 xbuild = "xtask build"
 xrelease = "xtask release"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,6 +3398,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "xlaunch"
+version = "0.5.3"
+
+[[package]]
 name = "xtask"
 version = "0.5.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kunai", "kunai-common", "xtask"]
+members = ["kunai", "kunai-common", "xlaunch", "xtask"]
 
 [workspace.package]
 version = "0.5.3"

--- a/xlaunch/Cargo.toml
+++ b/xlaunch/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "xlaunch"
+description = "Cross architecture xtask launcher"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]

--- a/xlaunch/src/main.rs
+++ b/xlaunch/src/main.rs
@@ -1,0 +1,26 @@
+use std::{env, error::Error};
+
+// we execute cargo run with a default target defined from the current
+// system architecture. This prevents hardcoding target in cargo xtask
+// alias, which is not portable
+fn main() -> Result<(), Box<dyn Error>> {
+    let default_target = format!("{}-unknown-linux-gnu", env::consts::ARCH);
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    let status = std::process::Command::new("cargo")
+        .arg("run")
+        .arg("-q")
+        .arg(format!("--target={}", default_target))
+        .arg("--release")
+        .arg("--package")
+        .arg("xtask")
+        .arg("--")
+        .args(args)
+        .status()?;
+
+    if !status.success() {
+        return Err(format!("command failed with status: {}", status).into());
+    }
+
+    Ok(())
+}

--- a/xtask/.cargo/config.toml
+++ b/xtask/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
Currently cargo alias are hardcoding the target which is not very portable.

The goal of this PR is to make cargo xtask commands cross architectures.
For the moment two architectures are supported x86_64 and aarch64