### PR TITLE
This PR fixes a compatibility issue with kernels >= 6.11

### DIFF
--- a/kunai-common/src/co_re/c/shim.c
+++ b/kunai-common/src/co_re/c/shim.c
@@ -220,6 +220,15 @@ struct inode
 	unsigned long i_ino;
 	struct super_block *i_sb;
 	loff_t i_size;
+	// mac time changed in kernel 6.11
+	// https://elixir.bootlin.com/linux/v6.11/source/include/linux/fs.h#L668
+	time64_t i_atime_sec;
+	time64_t i_mtime_sec;
+	time64_t i_ctime_sec;
+	u32 i_atime_nsec;
+	u32 i_mtime_nsec;
+	u32 i_ctime_nsec;
+	// use these kernels < 6.11
 	union
 	{
 		struct timespec64 i_atime;
@@ -243,10 +252,16 @@ SHIM(inode, i_sb);
 SHIM(inode, i_size);
 SHIM(inode, i_atime);
 SHIM(inode, __i_atime);
+SHIM(inode, i_atime_sec);
+SHIM(inode, i_atime_nsec);
 SHIM(inode, i_mtime);
 SHIM(inode, __i_mtime);
+SHIM(inode, i_mtime_sec);
+SHIM(inode, i_mtime_nsec);
 SHIM(inode, i_ctime);
 SHIM(inode, __i_ctime);
+SHIM(inode, i_ctime_sec);
+SHIM(inode, i_ctime_nsec);
 
 struct file
 {

--- a/kunai-common/src/co_re/core_fs.rs
+++ b/kunai-common/src/co_re/core_fs.rs
@@ -16,27 +16,55 @@ impl inode {
     rust_shim_kernel_impl!(inode, i_sb, super_block);
     rust_shim_kernel_impl!(inode, i_size, i64);
 
-    // handle i_atime member (renamed in 6.7)
+    // for kernels < 6.7
     rust_shim_kernel_impl!(pub(self),_i_atime, inode, i_atime, timespec64);
+    // for kernels in [6.7; 6.11]
     rust_shim_kernel_impl!(pub(self), ___i_atime, inode, __i_atime, timespec64);
+    // for kernels >= 6.11
+    rust_shim_kernel_impl!(pub(self), i_atime_sec, inode, i_atime_sec, i64);
+    rust_shim_kernel_impl!(pub(self), i_atime_nsec, inode, i_atime_nsec, i64);
 
     pub unsafe fn i_atime(&self) -> Option<timespec64> {
-        self._i_atime().or_else(|| self.___i_atime())
+        self._i_atime().or_else(|| self.___i_atime()).or_else(|| {
+            Some(timespec64 {
+                tv_sec: self.i_atime_sec()?,
+                tv_nsec: self.i_atime_nsec()?,
+            })
+        })
     }
 
-    // handle i_mtime member (renamed in 6.7)
+    // for kernels < 6.7
     rust_shim_kernel_impl!(pub(self),_i_mtime, inode, i_mtime, timespec64);
+    // for kernels in [6.7; 6.11]
     rust_shim_kernel_impl!(pub(self), ___i_mtime, inode, __i_mtime, timespec64);
+    // for kernels >= 6.11
+    rust_shim_kernel_impl!(pub(self),i_mtime_sec, inode, i_mtime_sec, i64);
+    rust_shim_kernel_impl!(pub(self),i_mtime_nsec, inode, i_mtime_nsec, i64);
 
     pub unsafe fn i_mtime(&self) -> Option<timespec64> {
-        self._i_mtime().or_else(|| self.___i_mtime())
+        self._i_mtime().or_else(|| self.___i_mtime()).or_else(|| {
+            Some(timespec64 {
+                tv_sec: self.i_mtime_sec()?,
+                tv_nsec: self.i_mtime_nsec()?,
+            })
+        })
     }
 
+    // for kernels < 6.6
     rust_shim_kernel_impl!(pub(self),_i_ctime, inode, i_ctime, timespec64);
+    // for kernels in [6.6; 6.11]
     rust_shim_kernel_impl!(pub(self), ___i_ctime, inode, __i_ctime, timespec64);
+    // for kernels >= 6.11
+    rust_shim_kernel_impl!(pub(self),i_ctime_sec, inode, i_ctime_sec, i64);
+    rust_shim_kernel_impl!(pub(self),i_ctime_nsec, inode, i_ctime_nsec, i64);
 
     pub unsafe fn i_ctime(&self) -> Option<timespec64> {
-        self._i_ctime().or_else(|| self.___i_ctime())
+        self._i_ctime().or_else(|| self.___i_ctime()).or_else(|| {
+            Some(timespec64 {
+                tv_sec: self.i_ctime_sec()?,
+                tv_nsec: self.i_ctime_nsec()?,
+            })
+        })
     }
 
     #[inline(always)]

--- a/kunai-common/src/co_re/gen.rs
+++ b/kunai-common/src/co_re/gen.rs
@@ -279,6 +279,12 @@ pub struct inode {
     pub i_ino: ::core::ffi::c_ulong,
     pub i_sb: *mut super_block,
     pub i_size: loff_t,
+    pub i_atime_sec: time64_t,
+    pub i_mtime_sec: time64_t,
+    pub i_ctime_sec: time64_t,
+    pub i_atime_nsec: u32_,
+    pub i_mtime_nsec: u32_,
+    pub i_ctime_nsec: u32_,
     pub __bindgen_anon_1: inode__bindgen_ty_1,
     pub __bindgen_anon_2: inode__bindgen_ty_2,
     pub __bindgen_anon_3: inode__bindgen_ty_3,
@@ -356,6 +362,24 @@ unsafe extern "C" {
     pub fn shim_inode___i_atime_exists(inode: *mut inode) -> bool;
 }
 unsafe extern "C" {
+    pub fn shim_inode_i_atime_sec(inode: *mut inode) -> ::core::ffi::c_longlong;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_atime_sec_user(inode: *mut inode) -> ::core::ffi::c_longlong;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_atime_sec_exists(inode: *mut inode) -> bool;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_atime_nsec(inode: *mut inode) -> ::core::ffi::c_uint;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_atime_nsec_user(inode: *mut inode) -> ::core::ffi::c_uint;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_atime_nsec_exists(inode: *mut inode) -> bool;
+}
+unsafe extern "C" {
     pub fn shim_inode_i_mtime(inode: *mut inode) -> timespec64;
 }
 unsafe extern "C" {
@@ -374,6 +398,24 @@ unsafe extern "C" {
     pub fn shim_inode___i_mtime_exists(inode: *mut inode) -> bool;
 }
 unsafe extern "C" {
+    pub fn shim_inode_i_mtime_sec(inode: *mut inode) -> ::core::ffi::c_longlong;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_mtime_sec_user(inode: *mut inode) -> ::core::ffi::c_longlong;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_mtime_sec_exists(inode: *mut inode) -> bool;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_mtime_nsec(inode: *mut inode) -> ::core::ffi::c_uint;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_mtime_nsec_user(inode: *mut inode) -> ::core::ffi::c_uint;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_mtime_nsec_exists(inode: *mut inode) -> bool;
+}
+unsafe extern "C" {
     pub fn shim_inode_i_ctime(inode: *mut inode) -> timespec64;
 }
 unsafe extern "C" {
@@ -390,6 +432,24 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn shim_inode___i_ctime_exists(inode: *mut inode) -> bool;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_ctime_sec(inode: *mut inode) -> ::core::ffi::c_longlong;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_ctime_sec_user(inode: *mut inode) -> ::core::ffi::c_longlong;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_ctime_sec_exists(inode: *mut inode) -> bool;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_ctime_nsec(inode: *mut inode) -> ::core::ffi::c_uint;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_ctime_nsec_user(inode: *mut inode) -> ::core::ffi::c_uint;
+}
+unsafe extern "C" {
+    pub fn shim_inode_i_ctime_nsec_exists(inode: *mut inode) -> bool;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This is due to a change in the MAC time is stored in `inode` structure.

Instead of a `timespec64` those are now two separate members of the struct. 

See https://elixir.bootlin.com/linux/v6.11/source/include/linux/fs.h#L668 for further details.