### PR TITLE
feat: add parent_command_line for execve and execve_script

### DIFF
--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -755,6 +755,17 @@ impl EventConsumer<'_> {
     }
 
     #[inline(always)]
+    fn get_parent_command_line(&self, i: &StdEventInfo) -> String {
+        let ck = i.process_key();
+        self.processes
+            .get(&ck)
+            .and_then(|t| t.real_parent_key)
+            .and_then(|ptk| self.processes.get(&ptk))
+            .map(|c| c.command_line.join(" "))
+            .unwrap_or("?".into())
+    }
+
+    #[inline(always)]
     fn get_parent_image(&self, i: &StdEventInfo) -> String {
         let ck = i.process_key();
         self.processes
@@ -880,6 +891,7 @@ impl EventConsumer<'_> {
 
         let mut data = ExecveData {
             ancestors,
+            parent_command_line: self.get_parent_command_line(&info),
             parent_exe: self.get_parent_image(&info),
             command_line: cli,
             exe: self.get_hashes_in_ns(opt_mnt_ns, &cache::Path::from(&event.data.executable)),

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -480,6 +480,7 @@ macro_rules! def_user_data {
 #[derive(Debug, Serialize, Deserialize, FieldGetter)]
 pub struct ExecveData {
     pub ancestors: String,
+    pub parent_command_line: String,
     pub parent_exe: String,
     pub command_line: String,
     pub exe: Hashes,


### PR DESCRIPTION
Hi, I added **parent_command_line** because parent arguments are very important within a single event when writing rules in a large number of cases. This field allows you to avoid writing complex sequence rules and write rules for detecting malicious activity within one event.

Example: In this case we can reliably track Interactive Terminal Spawned via Python. 
Executed bash via python using subprocess.
```json
{
    "data": {
        "ancestors": "/usr/lib/systemd/systemd|/usr/lib/systemd/systemd|/usr/bin/konsole|/usr/bin/zsh|/usr/bin/python3.13",
        "parent_exe": "/usr/bin/python3.13",
        "parent_command_line": "python3 -c \"import subprocess; subprocess.run('bash')\"",
        "command_line": "bash",
        "exe": {
            "path": "/usr/bin/bash",
            "md5": "af00f880da2e5211cbb988e18a726685",
            "sha1": "c9fb232382e02f21b54e6fd5f809ed18f63035b4",
            "sha256": "81d2cd600d7159006c5f35ac1e855928c5613c39611d78c189961ada88856109",
            "sha512": "91acf1709d62569008c3886d2f6e5105d74a0d1abe417478865044cd6b203a0fa048d6775080ae17f91f992d6543cba9878de5f5613866b5404ca8d590d4cd4c",
            "size": 1117048,
            "error": null
        }
    }
}
```
This example may not be the best one, but it was the first thing that came to mind. In this example, you can still try to get by with the parent process event and try to track the possible launch of the interactive shell, but this is not what you would like and may not work in all cases.
