### PR TITLE
fix: kunai utf8 decoding crash

### DIFF
--- a/kunai-common/src/buffer/user.rs
+++ b/kunai-common/src/buffer/user.rs
@@ -1,24 +1,38 @@
-use core::str;
+use core::str::{self, Utf8Error};
 
 use super::Buffer;
 
 impl<const N: usize> Buffer<N> {
+    /// Returns a tuple made of the argv and an optional last decoding error.
     #[inline]
-    pub fn to_argv(&self) -> Vec<String> {
-        self.as_slice()
-            .split(|&b| b == b'\0')
-            // this must not panic as we are sure to have utf8 from kernel
-            .map(|s| str::from_utf8(s).unwrap().to_string())
-            .filter(|s| !s.is_empty())
-            .map(|s| {
-                if s.chars().any(|c| c.is_whitespace()) {
-                    // we wrap strings containg space between double quotes
-                    // but we also need to replace double quotes by escaped double quotes
-                    format!(r#""{}""#, s.replace(r#"""#, r#"\""#))
-                } else {
-                    s
+    pub fn to_argv(&self) -> (Vec<String>, Option<Utf8Error>) {
+        let mut last_err = None;
+        let mut argv = vec![];
+
+        for s in self.as_slice().split(|&b| b == b'\0') {
+            let s = match str::from_utf8(s) {
+                Ok(s) => {
+                    if s.is_empty() {
+                        continue;
+                    }
+
+                    if s.chars().any(|c| c.is_whitespace()) {
+                        // we wrap strings containg space between double quotes
+                        // but we also need to replace double quotes by escaped double quotes
+                        &format!(r#""{}""#, s.replace(r#"""#, r#"\""#))
+                    } else {
+                        s
+                    }
                 }
-            })
-            .collect()
+                Err(e) => {
+                    let _ = last_err.insert(e);
+                    continue;
+                }
+            };
+
+            argv.push(s.to_string());
+        }
+
+        (argv, last_err)
     }
 }

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1581,6 +1581,16 @@ impl EventConsumer<'_> {
             e.children.insert(info.process_key());
         });
 
+        let (command_line, opt_err) = event.data.argv.to_argv();
+        opt_err.inspect(|e| {
+            error!(
+                "utf8 decoding error while parsing argv for comm={} pid={} task={}: {e}",
+                info.task_info().comm_string(),
+                info.task_info().tgid,
+                info.task_info().tg_uuid.into_uuid()
+            )
+        });
+
         // we insert only if not existing
         self.processes.entry(pk).or_insert(Process {
             image,

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1594,7 +1594,7 @@ impl EventConsumer<'_> {
         // we insert only if not existing
         self.processes.entry(pk).or_insert(Process {
             image,
-            command_line: event.data.argv.to_argv(),
+            command_line,
             pid: info.task_info().tgid,
             flags: info.task_info().flags,
             resolved: HashMap::new(),


### PR DESCRIPTION
Attempts at fixing: #193 

Kunai crashes attempting to parse non-utf8 code points in some process command lines. Instead of relying on `unwrap`  the `to_argv` function has been changed so that it both returns the argv (in a vec) and the latest decoding error. Instead of panicking Kunai now prints the error message (if any) in the logs. The default behavior is also to use the parsed argv containing arguments which could be decoded without errors.