### PR TITLE
feat: filter info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,8 +1194,10 @@ dependencies = [
 [[package]]
 name = "gene"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883e5554fd1f9fce23eeaf37f7a7b5326f94e32f33cce67d102c0d943682eb01"
 dependencies = [
- "gene_derive 0.5.0",
+ "gene_derive",
  "lazy_static",
  "pest",
  "pest_derive",
@@ -1203,15 +1205,6 @@ dependencies = [
  "serde",
  "serde_yaml",
  "thiserror 1.0.61",
-]
-
-[[package]]
-name = "gene_derive"
-version = "0.5.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -1685,7 +1678,7 @@ dependencies = [
  "flate2",
  "fs-walk",
  "gene",
- "gene_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gene_derive",
  "hex",
  "huby",
  "ip_network",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,11 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "gene"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2715f17a73ce6f65c988ed6b371dcf1781b80604d28879bc1cd77f1b4c76fc38"
+version = "0.5.0"
 dependencies = [
- "gene_derive",
+ "gene_derive 0.5.0",
  "lazy_static",
  "pest",
  "pest_derive",
@@ -1209,9 +1207,18 @@ dependencies = [
 
 [[package]]
 name = "gene_derive"
-version = "0.4.3"
+version = "0.5.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "gene_derive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ef5ab483abaf46b587dc094e05fac3b1550f8d4f01a0aee0910bed0521bb69"
+checksum = "7e4d912e26839093a23243b0950d89f7a4d13ef58a4647df591db300255a7b8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1678,7 +1685,7 @@ dependencies = [
  "flate2",
  "fs-walk",
  "gene",
- "gene_derive",
+ "gene_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "huby",
  "ip_network",
@@ -2169,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -2180,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2190,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2203,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -3241,9 +3248,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/kunai/Cargo.toml
+++ b/kunai/Cargo.toml
@@ -30,8 +30,8 @@ ip_network = "0.4"
 lru-st = { version = "0.2", features = ["sync"] }
 
 # detection engine for events
-gene = { version = "0.4" }
-gene_derive = { version = "0.4" }
+gene = { version = "0.5" }
+gene_derive = { version = "0.5" }
 
 anyhow = "1.0.68"
 env_logger = "0.10"

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -10,7 +10,7 @@ use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use env_logger::Builder;
 use flate2::bufread::GzDecoder;
 use fs_walk::WalkOptions;
-use gene::rules::{CompiledRule, MAX_SEVERITY};
+use gene::rules::CompiledRule;
 use gene::{Compiler, Engine};
 use huby::ByteSize;
 use kunai::containers::Container;
@@ -1741,10 +1741,10 @@ impl EventConsumer<'_> {
 
     #[inline(always)]
     fn scan<T: KunaiEvent>(&mut self, event: &mut T) -> Option<ScanResult> {
-        let mut scan_result: Option<ScanResult> = None;
+        let mut opt_scan_result: Option<ScanResult> = None;
 
         if !self.engine.is_empty() {
-            scan_result = match self.engine.scan(event) {
+            opt_scan_result = match self.engine.scan(event) {
                 Ok(sr) => sr.map(ScanResult::from),
                 Err((sr, e)) => {
                     error!("event scanning error: {e}");
@@ -1755,34 +1755,26 @@ impl EventConsumer<'_> {
 
         // no need to scan for IoC if not necessary
         if !self.iocs.is_empty() {
-            // we collect a vector of ioc matching
-            let matching_iocs = event
-                .iocs()
-                .iter()
-                .filter(|ioc| self.iocs.contains_key(&ioc.to_string()))
-                .map(|ioc| ioc.to_string())
-                .collect::<HashSet<String>>();
+            let iocs = event.iocs();
 
-            let ioc_severity: usize = matching_iocs
+            let mut matching_iocs = iocs
                 .iter()
-                .map(|ioc| self.iocs.get(ioc).map(|e| *e as usize).unwrap_or_default())
-                .sum();
+                .flat_map(|ioc| {
+                    self.iocs
+                        .get_key_value(&ioc.to_string())
+                        .map(|(i, s)| (i, *s))
+                })
+                .peekable();
 
-            if !matching_iocs.is_empty() {
-                // we create a new ScanResult if necessary
-                if scan_result.is_none() {
-                    scan_result = Some(ScanResult::default());
-                }
+            if matching_iocs.peek().is_some() {
+                let scan_result = opt_scan_result.get_or_insert_default();
 
                 // we add ioc matching to the list of matching rules
-                if let Some(sr) = scan_result.as_mut() {
-                    sr.iocs = matching_iocs;
-                    sr.severity = ioc_severity.clamp(0, MAX_SEVERITY as usize) as u8;
-                }
+                scan_result.update_iocs(matching_iocs);
             }
         }
 
-        scan_result
+        opt_scan_result
     }
 
     #[inline(always)]
@@ -1941,9 +1933,9 @@ impl EventConsumer<'_> {
 
         // scan for iocs and filter/matching rules
         if let Some(sr) = self.scan(event) {
-            if sr.is_detection() {
-                let severity = sr.severity;
-                event.set_detection(sr);
+            if let Some(d) = sr.detections {
+                let severity = d.severity;
+                event.set_detection(d);
 
                 // we print event only if needed
                 printed = if severity >= self.config.scanner.min_severity {
@@ -1953,12 +1945,14 @@ impl EventConsumer<'_> {
                 };
 
                 // get_detection will always be false for filters
-                if let Some(sr) = event.get_detection() {
-                    self.handle_actions(event, &sr.actions, true);
+                if let Some(d) = event.get_detection() {
+                    self.handle_actions(event, &d.actions, true)
                 }
             } else if sr.is_only_filter() {
                 printed = self.serialize_print(event);
-                self.handle_actions(event, &sr.actions, false);
+                if let Some(f) = sr.filters.as_ref() {
+                    self.handle_actions(event, &f.actions, true)
+                }
             }
         }
 

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -1933,7 +1933,7 @@ impl EventConsumer<'_> {
 
         // scan for iocs and filter/matching rules
         if let Some(sr) = self.scan(event) {
-            if let Some(d) = sr.detections {
+            if let Some(d) = sr.detection {
                 let severity = d.severity;
                 event.set_detection(d);
 
@@ -1948,10 +1948,12 @@ impl EventConsumer<'_> {
                 if let Some(d) = event.get_detection() {
                     self.handle_actions(event, &d.actions, true)
                 }
-            } else if sr.is_only_filter() {
+            }
+            if let Some(f) = sr.filter {
+                event.set_filter(f);
                 printed = self.serialize_print(event);
-                if let Some(f) = sr.filters.as_ref() {
-                    self.handle_actions(event, &f.actions, true)
+                if let Some(f) = event.get_filter() {
+                    self.handle_actions(event, &f.actions, false)
                 }
             }
         }

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -288,10 +288,10 @@ impl From<gene::Detections<'_>> for Detections {
     fn from(mut value: gene::Detections) -> Self {
         Self {
             iocs: HashSet::new(),
-            rules: value.rules.drain().map(|s| s.to_string()).collect(),
-            tags: value.tags.drain().map(|s| s.to_string()).collect(),
-            attack: value.attack.drain().map(|s| s.to_string()).collect(),
-            actions: value.actions.drain().map(|s| s.to_string()).collect(),
+            rules: value.rules.drain().map(|s| s.into_owned()).collect(),
+            tags: value.tags.drain().map(|s| s.into_owned()).collect(),
+            attack: value.attack.drain().map(|s| s.into_owned()).collect(),
+            actions: value.actions.drain().map(|s| s.into_owned()).collect(),
             severity: value.severity,
         }
     }
@@ -315,9 +315,9 @@ pub struct Filters {
 impl From<gene::Filters<'_>> for Filters {
     fn from(mut value: gene::Filters) -> Self {
         Self {
-            rules: value.rules.drain().map(|s| s.to_string()).collect(),
-            tags: value.tags.drain().map(|s| s.to_string()).collect(),
-            actions: value.actions.drain().map(|s| s.to_string()).collect(),
+            rules: value.rules.drain().map(|s| s.into_owned()).collect(),
+            tags: value.tags.drain().map(|s| s.into_owned()).collect(),
+            actions: value.actions.drain().map(|s| s.into_owned()).collect(),
         }
     }
 }


### PR DESCRIPTION
This PR add visibility on the filter matching an event, useful for:
- testing / debugging filters (see https://github.com/kunai-project/kunai/issues/190#issuecomment-2800110241)
- showing context about filters (through tags)

This feature required some modifications of the ScanResult structure as we needed to separate filter and detection matches.