### PR TITLE
refactor: EncodedEvent to EbpfEvent enum

### DIFF
--- a/kunai-common/src/bpf_events/events/bpf.rs
+++ b/kunai-common/src/bpf_events/events/bpf.rs
@@ -31,10 +31,10 @@ pub struct BpfProgData {
     pub loaded: bool,
 }
 
-pub type BpfSocketFilterEvent = Event<BpfSocketFilter>;
+pub type BpfSocketFilterEvent = Event<BpfSocketFilterData>;
 
 #[repr(C)]
-pub struct BpfSocketFilter {
+pub struct BpfSocketFilterData {
     pub socket_info: SocketInfo,
     pub filter: Buffer<2048>,
     pub filter_len: u16,

--- a/kunai-common/src/bpf_events/events/correlation.rs
+++ b/kunai-common/src/bpf_events/events/correlation.rs
@@ -1,5 +1,5 @@
 use super::{CloneEvent, ExecveEvent, MmapExecEvent, ScheduleEvent};
-use crate::bpf_events::{Event, Nodename, Type};
+use crate::bpf_events::{Event, EventInfo, Nodename, Type};
 use crate::path::Path;
 use crate::{buffer::Buffer, cgroup::Cgroup};
 
@@ -122,19 +122,19 @@ impl From<&MmapExecEvent> for HashEvent {
 }
 
 impl HashEvent {
-    pub fn from_execve_with_path(event: &ExecveEvent, p: Path) -> Self {
+    pub fn new(info: EventInfo, p: Path) -> Self {
         Self {
-            info: event.info,
+            info,
             data: p.into(),
         }
         .with_type(Type::CacheHash)
     }
 
     pub fn all_from_execve(event: &ExecveEvent) -> Vec<HashEvent> {
-        let mut v = vec![Self::from_execve_with_path(event, event.data.executable)];
+        let mut v = vec![Self::new(event.info, event.data.executable)];
 
         if event.data.interpreter != event.data.executable {
-            v.push(Self::from_execve_with_path(event, event.data.interpreter));
+            v.push(Self::new(event.info, event.data.interpreter));
         }
 
         v

--- a/kunai-common/src/bpf_events/events/send_entropy.rs
+++ b/kunai-common/src/bpf_events/events/send_entropy.rs
@@ -33,17 +33,17 @@ impl SendEntropyEvent {
 }
 
 not_bpf_target_code! {
-    impl SendEntropyEvent {
+    impl SendEntropyData {
         // we cannot do complicated operations of f32 in eBPF
         #[inline]
         pub fn shannon_entropy(&self) -> f32{
             let mut entropy = 0.0;
 
-            for &freq in &self.data.freq{
+            for &freq in &self.freq{
                 if freq == 0{
                     continue
                 }
-                let p = freq as f32 / self.data.freq_sum as f32;
+                let p = freq as f32 / self.freq_sum as f32;
                 entropy -= p * p.log2();
             }
 

--- a/kunai-common/src/bpf_events/user.rs
+++ b/kunai-common/src/bpf_events/user.rs
@@ -5,6 +5,15 @@ use serde::{Deserialize, Serialize};
 
 use thiserror::Error;
 
+use crate::bpf_events::{CorrelationEvent, HashEvent};
+
+use super::{
+    BpfProgLoadEvent, BpfSocketFilterEvent, CloneEvent, ConnectEvent, DnsQueryEvent, ErrorEvent,
+    Event, EventInfo, ExecveEvent, ExitEvent, FileEvent, FileRenameEvent, InitModuleEvent,
+    KillEvent, LogEvent, LossEvent, MmapExecEvent, MprotectEvent, PrctlEvent, PtraceEvent,
+    ScheduleEvent, SendEntropyEvent, SysCoreResumeEvent, Type, UnlinkEvent,
+};
+
 unsafe impl Pod for Type {}
 
 impl Display for Type {
@@ -32,114 +41,208 @@ impl<'de> Deserialize<'de> for Type {
     }
 }
 
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct EncodedEvent {
-    event: Vec<u8>,
-}
-
 #[derive(Error, Debug)]
 pub enum DecoderError {
     #[error("not enough bytes to decode")]
     NotEnoughBytes,
     #[error("size of buffer does not match with size of event")]
     SizeDontMatch,
+    #[error("unsupported event type: {0}")]
+    Unsupported(Type),
 }
 
-impl EncodedEvent {
-    pub fn from_bytes(bytes: &[u8]) -> Self {
-        Self {
-            event: Vec::from(bytes),
-        }
-    }
+pub enum EbpfEvent {
+    Execve(Box<ExecveEvent>),
+    Exit(Box<ExitEvent>),
+    Clone(Box<CloneEvent>),
+    Prctl(Box<PrctlEvent>),
+    Kill(Box<KillEvent>),
+    Ptrace(Box<PtraceEvent>),
+    InitModule(Box<InitModuleEvent>),
+    BpfProgLoad(Box<BpfProgLoadEvent>),
+    BpfSocketFilter(Box<BpfSocketFilterEvent>),
+    Mprotect(Box<MprotectEvent>),
+    MmapExec(Box<MmapExecEvent>),
+    Connect(Box<ConnectEvent>),
+    DnsQuery(Box<DnsQueryEvent>),
+    SendEntropy(Box<SendEntropyEvent>),
+    File(Box<FileEvent>),
+    FileRename(Box<FileRenameEvent>),
+    Unlink(Box<UnlinkEvent>),
+    // not configurable but filterable
+    Error(Box<ErrorEvent>),
+    Loss(Box<LossEvent>),
+    // specific events
+    Start(Box<Event<()>>),
+    Schedule(Box<ScheduleEvent>),
+    Correlation(Box<CorrelationEvent>),
+    Hash(Box<HashEvent>),
+    Log(Box<LogEvent>),
+    SysCoreResume(Box<SysCoreResumeEvent>),
+}
 
-    pub fn from_event<T>(event: Event<T>) -> Self {
-        Self::from_bytes(event.encode())
+impl From<HashEvent> for EbpfEvent {
+    fn from(value: HashEvent) -> Self {
+        Self::Hash(Box::new(value))
     }
+}
 
+impl From<LossEvent> for EbpfEvent {
+    fn from(value: LossEvent) -> Self {
+        Self::Loss(Box::new(value))
+    }
+}
+
+impl EbpfEvent {
     /// # Safety
     /// * the bytes decoded must be a valid Event<T>
-    #[inline(always)]
-    pub unsafe fn info(&self) -> Result<&EventInfo, DecoderError> {
+    #[inline]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DecoderError> {
         // event content must be at least the size of EventInfo
-        if self.event.len() < core::mem::size_of::<EventInfo>() {
+        if bytes.len() < core::mem::size_of::<EventInfo>() {
             return Err(DecoderError::NotEnoughBytes);
         }
 
-        Ok(&(*(self.event.as_ptr() as *const EventInfo)))
-    }
+        let info = unsafe {
+            &(*(bytes[0..core::mem::size_of::<EventInfo>()].as_ptr() as *const EventInfo))
+        };
 
-    /// Get event info without checking
-    /// # Safety
-    /// * the bytes decoded must be a valid Event<T>
-    #[inline(always)]
-    pub unsafe fn info_unchecked(&self) -> &EventInfo {
-        &(*(self.event.as_ptr() as *const EventInfo))
-    }
+        macro_rules! decode {
+            ($src: ident) => {{
+                if bytes.len() < $src::size_of() {
+                    return Err(DecoderError::SizeDontMatch);
+                }
 
-    /// # Safety
-    /// * the bytes decoded must be a valid Event<T>
-    #[inline(always)]
-    pub unsafe fn info_mut(&mut self) -> Result<&mut EventInfo, DecoderError> {
-        // event content must be at least the size of EventInfo
-        if self.event.len() < core::mem::size_of::<EventInfo>() {
-            return Err(DecoderError::NotEnoughBytes);
+                let mut buf = [0u8; $src::size_of()];
+                buf.copy_from_slice(&bytes[0..$src::size_of()]);
+                let e: $src = unsafe { core::mem::transmute::<[u8; $src::size_of()], $src>(buf) };
+                e
+            }};
         }
 
-        Ok(&mut (*(self.event.as_ptr() as *mut EventInfo)))
-    }
+        // check that we didn't send uninitialized events
+        debug_assert!(info.etype != Type::Unknown, "received unknown event");
 
-    /// # Safety
-    /// * the bytes decoded must be a valid Event<T>
-    #[inline(always)]
-    pub unsafe fn as_event_with_data<D>(&self) -> Result<&Event<D>, DecoderError> {
-        // must be at least the size of Event<T>
-        if self.event.len() < core::mem::size_of::<Event<D>>() {
-            return Err(DecoderError::SizeDontMatch);
+        match info.etype {
+            // here ExecveScript cannot exist
+            Type::Execve | Type::ExecveScript => {
+                let mut execve_event = decode!(ExecveEvent);
+                if execve_event.data.interpreter != execve_event.data.executable {
+                    execve_event.info.etype = Type::ExecveScript
+                }
+                Ok(Self::Execve(Box::new(execve_event)))
+            }
+            Type::Exit | Type::ExitGroup => Ok(Self::Exit(Box::new(decode!(ExitEvent)))),
+            Type::Clone => Ok(Self::Clone(Box::new(decode!(CloneEvent)))),
+            Type::Prctl => Ok(Self::Prctl(Box::new(decode!(PrctlEvent)))),
+            Type::Kill => Ok(Self::Kill(Box::new(decode!(KillEvent)))),
+            Type::Ptrace => Ok(Self::Ptrace(Box::new(decode!(PtraceEvent)))),
+            Type::InitModule => Ok(Self::InitModule(Box::new(decode!(InitModuleEvent)))),
+            Type::BpfProgLoad => Ok(Self::BpfProgLoad(Box::new(decode!(BpfProgLoadEvent)))),
+            Type::BpfSocketFilter => Ok(Self::BpfSocketFilter(Box::new(decode!(
+                BpfSocketFilterEvent
+            )))),
+            Type::MprotectExec => Ok(Self::Mprotect(Box::new(decode!(MprotectEvent)))),
+            Type::MmapExec => Ok(Self::MmapExec(Box::new(decode!(MmapExecEvent)))),
+            Type::Connect => Ok(Self::Connect(Box::new(decode!(ConnectEvent)))),
+            Type::DnsQuery => Ok(Self::DnsQuery(Box::new(decode!(DnsQueryEvent)))),
+            Type::SendData => Ok(Self::SendEntropy(Box::new(decode!(SendEntropyEvent)))),
+            Type::Read
+            | Type::ReadConfig
+            | Type::Write
+            | Type::WriteConfig
+            | Type::WriteClose
+            | Type::FileCreate => Ok(Self::File(Box::new(decode!(FileEvent)))),
+            Type::FileRename => Ok(Self::FileRename(Box::new(decode!(FileRenameEvent)))),
+            Type::FileUnlink => Ok(Self::Unlink(Box::new(decode!(UnlinkEvent)))),
+            // not configurable events
+            Type::TaskSched => Ok(Self::Schedule(Box::new(decode!(ScheduleEvent)))),
+            Type::Correlation => Ok(Self::Correlation(Box::new(decode!(CorrelationEvent)))),
+            Type::CacheHash => Ok(Self::Hash(Box::new(decode!(HashEvent)))),
+            Type::Log => Ok(Self::Log(Box::new(decode!(LogEvent)))),
+            Type::Loss => Ok(Self::Loss(Box::new(decode!(LossEvent)))),
+            Type::Error => Ok(Self::Error(Box::new(decode!(ErrorEvent)))),
+            Type::SyscoreResume => Ok(Self::SysCoreResume(Box::new(decode!(SysCoreResumeEvent)))),
+            Type::EndConfigurable | Type::Max | Type::Start | Type::FileScan | Type::Unknown => {
+                Err(DecoderError::Unsupported(info.etype))
+            }
         }
-
-        Ok(&(*(self.event.as_ptr() as *const Event<D>)))
     }
 
-    /// # Safety
-    /// * the bytes decoded must be a valid Event<T>
     #[inline(always)]
-    pub unsafe fn as_mut_event_with_data<D>(&mut self) -> Result<&mut Event<D>, DecoderError> {
-        // must be at least the size of Event<T>
-        if self.event.len() < core::mem::size_of::<Event<D>>() {
-            return Err(DecoderError::SizeDontMatch);
-        }
+    pub fn ty(&self) -> Type {
+        self.info().etype
+    }
 
-        Ok(&mut (*(self.event.as_mut_ptr() as *mut Event<D>)))
+    #[inline(always)]
+    pub fn info(&self) -> &EventInfo {
+        match self {
+            Self::Execve(e) => &e.info,
+            Self::Exit(e) => &e.info,
+            Self::Clone(e) => &e.info,
+            Self::Prctl(e) => &e.info,
+            Self::Kill(e) => &e.info,
+            Self::Ptrace(e) => &e.info,
+            Self::InitModule(e) => &e.info,
+            Self::BpfProgLoad(e) => &e.info,
+            Self::BpfSocketFilter(e) => &e.info,
+            Self::Mprotect(e) => &e.info,
+            Self::MmapExec(e) => &e.info,
+            Self::Connect(e) => &e.info,
+            Self::DnsQuery(e) => &e.info,
+            Self::SendEntropy(e) => &e.info,
+            Self::File(e) => &e.info,
+            Self::FileRename(e) => &e.info,
+            Self::Unlink(e) => &e.info,
+            Self::Error(e) => &e.info,
+            Self::Loss(e) => &e.info,
+            Self::Start(e) => &e.info,
+            Self::Schedule(e) => &e.info,
+            Self::Correlation(e) => &e.info,
+            Self::Hash(e) => &e.info,
+            Self::Log(e) => &e.info,
+            Self::SysCoreResume(e) => &e.info,
+        }
+    }
+
+    #[inline(always)]
+    pub fn info_mut(&mut self) -> &mut EventInfo {
+        match self {
+            Self::Execve(e) => &mut e.info,
+            Self::Exit(e) => &mut e.info,
+            Self::Clone(e) => &mut e.info,
+            Self::Prctl(e) => &mut e.info,
+            Self::Kill(e) => &mut e.info,
+            Self::Ptrace(e) => &mut e.info,
+            Self::InitModule(e) => &mut e.info,
+            Self::BpfProgLoad(e) => &mut e.info,
+            Self::BpfSocketFilter(e) => &mut e.info,
+            Self::Mprotect(e) => &mut e.info,
+            Self::MmapExec(e) => &mut e.info,
+            Self::Connect(e) => &mut e.info,
+            Self::DnsQuery(e) => &mut e.info,
+            Self::SendEntropy(e) => &mut e.info,
+            Self::File(e) => &mut e.info,
+            Self::FileRename(e) => &mut e.info,
+            Self::Unlink(e) => &mut e.info,
+            Self::Error(e) => &mut e.info,
+            Self::Loss(e) => &mut e.info,
+            Self::Start(e) => &mut e.info,
+            Self::Schedule(e) => &mut e.info,
+            Self::Correlation(e) => &mut e.info,
+            Self::Hash(e) => &mut e.info,
+            Self::Log(e) => &mut e.info,
+            Self::SysCoreResume(e) => &mut e.info,
+        }
+    }
+
+    #[inline(always)]
+    pub fn set_batch(&mut self, n: u64) {
+        self.info_mut().batch = n
+    }
+
+    #[inline(always)]
+    pub fn switch_type(&mut self, ty: Type) {
+        self.info_mut().etype = ty
     }
 }
-
-#[macro_export]
-macro_rules! mut_event {
-    ($enc: expr) => {
-        unsafe { $enc.as_mut_event_with_data() }
-    };
-    ($enc:expr, $event:ty) => {{
-        let event: Result<&mut $event, $crate::bpf_events::DecoderError> =
-            unsafe { $enc.as_mut_event_with_data() };
-        event
-    }};
-}
-
-pub use mut_event;
-
-#[macro_export]
-macro_rules! event {
-    ($enc: expr) => {
-        unsafe { $enc.as_event_with_data() }
-    };
-    ($enc:expr, $event:ty) => {{
-        let event: Result<&$event, $crate::bpf_events::DecoderError> =
-            unsafe { $enc.as_event_with_data() };
-        event
-    }};
-}
-
-pub use event;
-
-use super::{Event, EventInfo, Type};


### PR DESCRIPTION
This PR refactor the way eBPF events are treated in userland.

Motivation:
- code heavily relying on macros
- code could be simplified by the use of an enum

A side effect of this refactor is a **15% event throughput increase** due to the code simplifications.

This refactoring activity lead to the discovery of: #205 