### PR TITLE
fix: attempt at forcing bpf-linker version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,6 @@ jobs:
         sudo apt update
         sudo apt install -y ${{ matrix.packages }} libbpf-dev
     
-    - name: Build tools versions
-      run: |
-        echo "Clang version"
-        clang --version
-        echo 
-
-        echo "bpf-linker version"
-        bpf-linker -V
-
-        
     # we need to fetch rust deps first to speed up cargo xtask
     - name: Cache Rust dependencies
       uses: actions/cache@v4
@@ -102,6 +92,15 @@ jobs:
           ~/.rustup
           target
         key: ${{ runner.os }}-${{ matrix.arch }}-rust-${{ hashFiles('**/Cargo.lock', '**/.github/workflows/ci.yml') }}
+
+    - name: Build tools versions
+      run: |
+        echo "Clang version"
+        clang --version
+        echo 
+
+        echo "bpf-linker version"
+        bpf-linker -V
       
     - name: Set kernel cache key
       run: echo "KERNEL_CACHE_KEY=cache-vmlinuz-${{ matrix.arch }}-cache-$(date +%Y-%m-%d)" >> $GITHUB_ENV


### PR DESCRIPTION
The CI/CD fails with a an error at BPF load time

```
ERROR tests] FAILURE: BTF error: the BPF_BTF_LOAD syscall failed. Verifier output: magic: 0xeb9f
[...]
     [140] STRUCT sockaddr_in size=16 vlen=4
    	sin_family type_id=134 bits_offset=0
    	sin_port type_id=69 bits_offset=
```

This is an error I don't manage to reproduce on my side, so it is assumed this is an issue with the build tools.
Usual suspects:
1. `bpf-linker`
2. `clang`