### PR TITLE
fix: remove detection/filter sections before replay

### DIFF
--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -3374,11 +3374,17 @@ impl Command {
 
             let mut de = serde_json::Deserializer::from_reader(reader);
 
-            while let Ok(v) = serde_json::Value::deserialize(&mut de) {
+            while let Ok(mut v) = serde_json::Value::deserialize(&mut de) {
                 // we need to know the size of the data we scan to compute throughput
                 if bench {
                     data_size += ByteSize::from_bytes(serde_json::to_string(&v)?.len() as u64);
                 }
+
+                // we remove any prior filter/detection sections
+                if let serde_json::Value::Object(map) = &mut v {
+                    map.remove("filter");
+                    map.remove("detection");
+                };
 
                 let mut e = ReplayEvent::try_from(v.clone())?;
                 if bench {


### PR DESCRIPTION
This PR ensures that when using the `replay` command on logs already processed by Kunai, the `detection` and `filter` sections are removed from the JSON. This prevents confusion, as the event will be rescanned and should not retain outdated scanning information.

## Motivation
During a replay, logs are reprocessed by the event scanning engine. Retaining the `detection` and `filter` sections from a previous scan could lead to misleading or conflicting information, as these sections are specific to the original scan context.

## Changes
- **Log replay logic**: Removed `detection` and `filter` sections from JSON output before reprocessing.