### PR TITLE
fix(ebpf): AllocError error comming from io_uring probe

### DIFF
--- a/kunai-ebpf/src/probes/io_uring.rs
+++ b/kunai-ebpf/src/probes/io_uring.rs
@@ -50,6 +50,8 @@ fn handle_issue_sqe(ctx: ProbeContext) -> u32 {
 unsafe fn try_io_issue_sqe(ctx: &ProbeContext) -> ProbeResult<()> {
     let req = io_kiocb::from_ptr(kprobe_arg!(ctx, 0)?);
 
+    alloc::init()?;
+
     let event = alloc::alloc_zero::<IoUringSqeEvent>()?;
 
     event.init_from_current_task(Type::IoUringSqe)?;
@@ -83,6 +85,8 @@ pub fn enter_io_submit_sqe(ctx: ProbeContext) -> u32 {
 unsafe fn try_io_submit_sqe(ctx: &ProbeContext) -> ProbeResult<()> {
     // Assuming the first argument is the io_kiocb pointer, similar to io_issue_sqe
     let s = sqe_submit::from_ptr(kprobe_arg!(ctx, 2)?);
+
+    alloc::init()?;
 
     let event = alloc::alloc_zero::<IoUringSqeEvent>()?;
 


### PR DESCRIPTION
fixes following error

```
probes::io_uring line=43 pid=1045766 tgid=1045766 comm=node AllocError: no more place to allocate
```