### PR TITLE
fix(build): ensure eBPF rebuilds on dep change

### DIFF
--- a/kunai/build.rs
+++ b/kunai/build.rs
@@ -6,10 +6,18 @@ fn main() -> anyhow::Result<()> {
         .no_deps()
         .exec()
         .context("MetadataCommand::exec")?;
+
+    for p in packages.iter() {
+        if let Some(d) = p.manifest_path.parent() {
+            println!("cargo:rerun-if-changed={}", d);
+        }
+    }
+
     let ebpf_package = packages
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name.as_str() == "kunai-ebpf")
         .ok_or_else(|| anyhow!("kunai-ebpf package not found"))?;
+
     let cargo_metadata::Package {
         name,
         manifest_path,


### PR DESCRIPTION
**Summary**
Fix eBPF build script to properly detect dependency changes and trigger rebuilds.

**Motivation**
The build script did not re-run when eBPF package dependencies changed, resulting in stale builds. 

**Changes**
- Add `cargo:rerun-if-changed` directives for all package manifest directories in `kunai/build.rs`

**Testing**
- Modify a dependency in the workspace and verify eBPF components rebuild
- Run `cargo build` and confirm build script re-executes on dependency changes
