### PR TITLE
feat(config): derive host UUID from env

### DIFF
--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -330,13 +330,9 @@ impl EventConsumer<'_> {
         Ok(out)
     }
 
-    pub fn with_config(mut config: Config) -> anyhow::Result<Self> {
+    pub fn with_config(config: Config) -> anyhow::Result<Self> {
         // building up system information
-        let system_info = SystemInfo::from_sys()?.with_host_uuid(
-            config
-                .host_uuid()
-                .ok_or(anyhow!("failed to read host_uuid"))?,
-        );
+        let system_info = SystemInfo::from_sys()?.with_host_uuid(config.host_uuid);
 
         let scan_events_enabled = config
             .events
@@ -3715,7 +3711,7 @@ impl Command {
 
     fn config(co: ConfigOpt) -> anyhow::Result<()> {
         if co.dump {
-            let conf = Config::default().generate_host_uuid();
+            let conf = Config::default();
             // do not use println because to_string already includes a
             // trailing newline. Using print! allow one to easily compute
             // config hash as the one found in start event.
@@ -3903,16 +3899,13 @@ WantedBy=sysinit.target"#,
         fs::create_dir_all(config_dir)?;
 
         // create configuration for installation
-        let conf = Config::default()
-            .harden(o.harden)
-            .generate_host_uuid()
-            .output(config::Output {
-                path: log_path.to_string_lossy().to_string(),
-                rotate_size: Some(huby::ByteSize::from_mb(10)),
-                rotate_interval: Some(Duration::from_mins(15)),
-                max_size: Some(huby::ByteSize::from_gb(1)),
-                buffered: false,
-            });
+        let conf = Config::default().harden(o.harden).output(config::Output {
+            path: log_path.to_string_lossy().to_string(),
+            rotate_size: Some(huby::ByteSize::from_mb(10)),
+            rotate_interval: Some(Duration::from_mins(15)),
+            max_size: Some(huby::ByteSize::from_gb(1)),
+            buffered: false,
+        });
 
         let mut overwrite_config = !config_path.exists();
         // we write configuration file

--- a/kunai/src/config.rs
+++ b/kunai/src/config.rs
@@ -6,9 +6,11 @@ use kunai_common::{
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
+    env::var,
     fs,
     ops::{Div, Mul},
     path::PathBuf,
+    str::FromStr,
     time::Duration,
 };
 use thiserror::Error;
@@ -76,7 +78,7 @@ pub struct Scanner {
 /// Kunai configuration structure to be used in userland
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
-    host_uuid: Option<uuid::Uuid>,
+    pub host_uuid: uuid::Uuid,
     pub max_buffered_events: u16,
     pub max_eps_fs: Option<u64>,
     pub workers: Option<usize>,
@@ -104,7 +106,7 @@ impl Default for Config {
         }
 
         Self {
-            host_uuid: None,
+            host_uuid: Config::default_host_uuid(),
             max_buffered_events: DEFAULT_MAX_BUFFERED_EVENTS,
             // this x2 rule generally works for small values of max_buffered_events
             max_eps_fs: Some(DEFAULT_MAX_BUFFERED_EVENTS as u64 * 2),
@@ -131,17 +133,25 @@ impl Default for Config {
     }
 }
 
-fn host_uuid() -> Option<uuid::Uuid> {
+fn derive_uuid_from<B: AsRef<[u8]>>(bytes: B) -> uuid::Uuid {
+    uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, bytes.as_ref())
+}
+
+fn host_uuid_from_machine_id() -> Option<uuid::Uuid> {
     if let Ok(machine_id) = fs::read_to_string("/etc/machine-id") {
         let machine_id = machine_id.trim_end();
         // we do not generate uuid if machine_id is empty string
         if machine_id.is_empty() {
             return None;
         }
-        return Some(uuid::Uuid::new_v5(
-            &uuid::Uuid::NAMESPACE_OID,
-            machine_id.as_bytes(),
-        ));
+        return Some(derive_uuid_from(machine_id));
+    }
+    None
+}
+
+fn host_uuid_from_boot_id() -> Option<uuid::Uuid> {
+    if let Ok(boot_id) = fs::read_to_string("/proc/sys/kernel/random/boot_id") {
+        return uuid::Uuid::from_str(boot_id.trim_end()).ok();
     }
     None
 }
@@ -154,12 +164,14 @@ impl Config {
         }
     }
 
-    pub fn host_uuid(&mut self) -> Option<uuid::Uuid> {
-        // host_uuid in config supersedes system host_uuid
-        self.host_uuid.or(host_uuid()).and_then(|u| {
-            self.host_uuid = Some(u);
-            self.host_uuid
-        })
+    fn default_host_uuid() -> uuid::Uuid {
+        var("KUNAI_HOST_UUID_SEED")
+            .ok()
+            .map(|seed| derive_uuid_from(&seed))
+            .or(host_uuid_from_machine_id())
+            // allow to at least have something stable accross runs
+            .or(host_uuid_from_boot_id())
+            .unwrap_or(uuid::Uuid::new_v4())
     }
 
     pub fn harden(mut self, value: bool) -> Self {
@@ -180,11 +192,6 @@ impl Config {
             rotate_interval: None,
             buffered: false,
         };
-        self
-    }
-
-    pub fn generate_host_uuid(mut self) -> Self {
-        self.host_uuid = host_uuid().or(Some(uuid::Uuid::new_v4()));
         self
     }
 
@@ -279,7 +286,14 @@ mod test {
 
     #[test]
     fn test_machine_uuid() {
-        let uuid = host_uuid();
+        let uuid = host_uuid_from_machine_id();
+        assert!(uuid.is_some());
+        println!("machine uuid: {}", uuid.unwrap())
+    }
+
+    #[test]
+    fn test_boot_id_uuid() {
+        let uuid = host_uuid_from_boot_id();
         assert!(uuid.is_some());
         println!("machine uuid: {}", uuid.unwrap())
     }


### PR DESCRIPTION
**Summary**
Derive host UUID from `KUNAI_HOST_UUID_SEED` environment variable, with an extended fallback chain including `/proc/sys/kernel/random/boot_id`. Enables stable host identification in containerized environments.

**Motivation**
In Kubernetes and other containerized environments, `/etc/machine-id` may be absent or unreliable. Using `KUNAI_HOST_UUID_SEED` allows deployments to provide a stable identifier. The addition of boot ID as a fallback provides another reliable system source.

**Changes**
- Add `KUNAI_HOST_UUID_SEED` environment variable support for UUID derivation
- Introduce `derive_uuid_from` helper using UUID v5 (OID namespace)
- Add fallback to `/proc/sys/kernel/random/boot_id` for systems without `/etc/machine-id`
- Change `host_uuid` from `Option<Uuid>` to `Uuid` with direct initialization via `default_host_uuid()`
- Remove obsolete `generate_host_uuid()` method
- Add tests for machine-id and boot-id UUID derivation

**Breaking Changes**
- `host_uuid` field is now always populated (removed `Option`)
- `generate_host_uuid()` method removed

**Testing**
Tests added for `host_uuid_from_machine_id()` and `host_uuid_from_boot_id()`

**Notes**
Kubernetes example:
```yaml
env:
  - name: KUNAI_HOST_UUID_SEED
    valueFrom:
      fieldRef:
        fieldPath: spec.nodeName
```

fix #251 