### PR TITLE
fix: #[repr(C)] in shared structures

### DIFF
--- a/kunai-common/src/alloc.rs
+++ b/kunai-common/src/alloc.rs
@@ -7,6 +7,7 @@ use kunai_macros::BpfError;
 
 use super::errors::ProbeError;
 
+#[repr(C)]
 #[derive(BpfError, Clone, Copy)]
 pub enum Error {
     #[error("failed to get allocator")]

--- a/kunai-common/src/bpf_events.rs
+++ b/kunai-common/src/bpf_events.rs
@@ -1,6 +1,7 @@
 use crate::buffer::Buffer;
 use crate::errors::ProbeError;
 use crate::macros::test_flag;
+use crate::option::BpfOption;
 use crate::uuid::{ProcUuid, Uuid};
 use kunai_macros::{BpfError, StrEnum};
 
@@ -199,7 +200,7 @@ pub struct TaskInfo {
     pub pid: i32,
     // task group uuid -> used to group tasks
     pub tg_uuid: ProcUuid,
-    pub namespaces: Option<Namespaces>,
+    pub namespaces: BpfOption<Namespaces>,
     pub start_time: u64,
 }
 

--- a/kunai-common/src/bpf_events/bpf.rs
+++ b/kunai-common/src/bpf_events/bpf.rs
@@ -6,6 +6,7 @@ use super::TaskInfo;
 use super::Type;
 use crate::co_re::core_read_kernel;
 use crate::co_re::task_struct;
+use crate::option::BpfOption;
 use crate::uuid::Uuid;
 use aya_ebpf::helpers::{bpf_get_current_task, bpf_ktime_get_ns};
 
@@ -79,7 +80,7 @@ impl TaskInfo {
             // it may happen that under some very specific conditions nsproxy
             // gets null (see https://github.com/kunai-project/kunai/issues/34)
             if !nsproxy.is_null() {
-                self.namespaces = Some(Namespaces {
+                self.namespaces = BpfOption::Some(Namespaces {
                     mnt: core_read_kernel!(nsproxy, mnt_ns, ns, inum)
                         .ok_or(Error::MntNamespaceFailure)?,
                 });

--- a/kunai-common/src/bpf_events/events/bpf.rs
+++ b/kunai-common/src/bpf_events/events/bpf.rs
@@ -1,4 +1,5 @@
 use crate::bpf_events::Event;
+use crate::option::BpfOption;
 use crate::{buffer::Buffer, net::SocketInfo, string::String};
 
 pub const KSYM_NAME_LEN: usize = 512;
@@ -26,8 +27,8 @@ pub struct BpfProgData {
     pub attached_func_name: String<512>,
     pub prog_type: u32,
     pub attach_type: u32,
-    pub hashes: Option<ProgHashes>,
-    pub verified_insns: Option<u32>,
+    pub hashes: BpfOption<ProgHashes>,
+    pub verified_insns: BpfOption<u32>,
     pub loaded: bool,
 }
 

--- a/kunai-common/src/bpf_events/events/log.rs
+++ b/kunai-common/src/bpf_events/events/log.rs
@@ -1,4 +1,4 @@
-use crate::{bpf_events::Event, errors::ProbeError, string::String};
+use crate::{bpf_events::Event, errors::ProbeError, option::BpfOption, string::String};
 
 pub type LogEvent = Event<LogData>;
 
@@ -15,8 +15,8 @@ pub struct LogData {
     pub location: String<32>,
     pub line: u32,
     pub level: Level,
-    pub error: Option<ProbeError>,
-    pub message: Option<String<64>>,
+    pub error: BpfOption<ProbeError>,
+    pub message: BpfOption<String<64>>,
 }
 
 #[cfg(target_arch = "bpf")]
@@ -57,11 +57,11 @@ mod user {
                 self.info.process.comm_str(),
             )?;
 
-            if let Some(msg) = self.data.message.as_ref() {
+            if let BpfOption::Some(msg) = self.data.message.as_ref() {
                 write!(f, " {}", msg,)?;
             }
 
-            if let Some(e) = self.data.error.as_ref() {
+            if let BpfOption::Some(e) = self.data.error.as_ref() {
                 write!(f, " {}: {}", e.name(), e.description())?;
             }
             Ok(())

--- a/kunai-common/src/buffer.rs
+++ b/kunai-common/src/buffer.rs
@@ -91,6 +91,7 @@ impl<const N: usize> Buffer<N> {
     }
 }
 
+#[repr(C)]
 #[derive(BpfError, Clone, Copy)]
 pub enum Error {
     #[error("bpf_probe_read failed")]

--- a/kunai-common/src/cgroup.rs
+++ b/kunai-common/src/cgroup.rs
@@ -18,6 +18,7 @@ pub struct Cgroup {
     pub error: Option<Error>,
 }
 
+#[repr(C)]
 #[derive(BpfError, Debug, Clone, Copy)]
 pub enum Error {
     #[error("failed to read cgroup.kn")]

--- a/kunai-common/src/cgroup.rs
+++ b/kunai-common/src/cgroup.rs
@@ -1,4 +1,4 @@
-use crate::errors::ProbeError;
+use crate::{errors::ProbeError, option::BpfOption};
 use kunai_macros::BpfError;
 
 #[cfg(feature = "user")]
@@ -15,7 +15,7 @@ const CGROUP_STRING_LEN: usize = CGROUP_PATH_MAX * 2;
 #[derive(Debug, Clone, Copy)]
 pub struct Cgroup {
     path: crate::string::String<CGROUP_STRING_LEN>,
-    pub error: Option<Error>,
+    pub error: BpfOption<Error>,
 }
 
 #[repr(C)]

--- a/kunai-common/src/cgroup/bpf.rs
+++ b/kunai-common/src/cgroup/bpf.rs
@@ -1,4 +1,7 @@
-use crate::co_re::{self, core_read_kernel};
+use crate::{
+    co_re::{self, core_read_kernel},
+    option::BpfOption,
+};
 
 use super::{Cgroup, Error};
 
@@ -10,7 +13,7 @@ impl Cgroup {
     #[inline(always)]
     pub unsafe fn resolve(&mut self, cgroup: co_re::cgroup) -> Result<(), Error> {
         // initialize error
-        self.error = None;
+        self.error = BpfOption::None;
 
         if cgroup.is_null() {
             return Ok(());
@@ -21,7 +24,7 @@ impl Cgroup {
         for _ in 0..MAX_CGROUP_DEPTH {
             let kn_name = core_read_kernel!(kn, name).ok_or(Error::KnName)?;
             self.path.append_kernel_str_bytes(kn_name).map_err(|_| {
-                self.error = Some(Error::Append);
+                self.error = BpfOption::Some(Error::Append);
                 Error::Append
             })?;
 
@@ -31,7 +34,7 @@ impl Cgroup {
             }
 
             self.path.push_char('/').map_err(|_| {
-                self.error = Some(Error::Append);
+                self.error = BpfOption::Some(Error::Append);
                 Error::Append
             })?;
         }

--- a/kunai-common/src/errors/bpf.rs
+++ b/kunai-common/src/errors/bpf.rs
@@ -2,6 +2,7 @@ use aya_ebpf::{macros::map, maps::LruPerCpuHashMap, EbpfContext};
 
 use crate::{
     bpf_events::{log, LogEvent},
+    option::BpfOption,
     string::String,
 };
 
@@ -50,11 +51,12 @@ macro_rules! probe_name {
     }};
 }
 
+#[repr(C)]
 pub struct Args {
     pub line: u32,
     pub location: String<32>,
-    pub message: Option<String<64>>,
-    pub err: Option<ProbeError>,
+    pub message: BpfOption<String<64>>,
+    pub err: BpfOption<ProbeError>,
     pub level: log::Level,
 }
 
@@ -86,9 +88,9 @@ macro_rules! log {
                 location: _PROBE_NAME,
                 message: {
                     if !$msg.is_empty() {
-                        Some(_MSG)
+                        $crate::option::BpfOption::Some(_MSG)
                     } else {
-                        None
+                        $crate::option::BpfOption::None
                     }
                 },
                 err: $err,
@@ -104,18 +106,28 @@ macro_rules! log {
 macro_rules! error {
     // literal must be evaluated first
     ($ctx:expr, $msg:literal) => {
-        $crate::log!($ctx, $msg, None, $crate::bpf_events::log::Level::Error)
+        $crate::log!(
+            $ctx,
+            $msg,
+            $crate::option::BpfOption::None,
+            $crate::bpf_events::log::Level::Error
+        )
     };
 
     ($ctx:expr, $err:expr) => {
-        $crate::log!($ctx, "", Some($err), $crate::bpf_events::log::Level::Error)
+        $crate::log!(
+            $ctx,
+            "",
+            $crate::option::BpfOption::Some($err),
+            $crate::bpf_events::log::Level::Error
+        )
     };
 
     ($ctx:expr, $msg:literal, $err:expr) => {
         $crate::log!(
             $ctx,
             $msg,
-            Some($err),
+            $crate::option::BpfOption::Some($err),
             $crate::bpf_events::log::Level::Error
         );
     };
@@ -125,14 +137,29 @@ macro_rules! error {
 macro_rules! warn {
     // literal must be evaluated first
     ($ctx:expr, $msg:literal) => {
-        $crate::log!($ctx, $msg, None, $crate::bpf_events::log::Level::Warn)
+        $crate::log!(
+            $ctx,
+            $msg,
+            $crate::option::BpfOption::None,
+            $crate::bpf_events::log::Level::Warn
+        )
     };
 
     ($ctx:expr, $err:expr) => {
-        $crate::log!($ctx, "", Some($err), $crate::bpf_events::log::Level::Warn);
+        $crate::log!(
+            $ctx,
+            "",
+            $crate::option::BpfOption::Some($err),
+            $crate::bpf_events::log::Level::Warn
+        );
     };
 
     ($ctx:expr, $msg:literal, $err:expr) => {
-        $crate::log!($ctx, $msg, Some($err), $crate::bpf_events::log::Level::Warn);
+        $crate::log!(
+            $ctx,
+            $msg,
+            $crate::option::BpfOption::Some($err),
+            $crate::bpf_events::log::Level::Warn
+        );
     };
 }

--- a/kunai-common/src/errors/bpf.rs
+++ b/kunai-common/src/errors/bpf.rs
@@ -1,4 +1,4 @@
-use aya_ebpf::{macros::map, maps::LruPerCpuHashMap, EbpfContext};
+use aya_ebpf::{macros::map, maps::LruPerCpuHashMap};
 
 use crate::{
     bpf_events::{log, LogEvent},
@@ -60,22 +60,6 @@ pub struct Args {
     pub level: log::Level,
 }
 
-#[inline(always)]
-pub unsafe fn log_with_args<C: EbpfContext>(ctx: &C, args: &Args) {
-    let _ = LOGS.insert(&0, &(*(EMPTY_LOG.as_ptr() as *const LogEvent)), 0);
-    if let Some(e) = LOGS.get_ptr_mut(&0) {
-        let e = &mut *e;
-        e.init_with_level(args.level);
-        e.info.etype = bpf_events::Type::Log;
-        e.data.location.clone_from(&args.location);
-        e.data.line = args.line;
-        e.data.error = args.err;
-        e.data.message = args.message;
-
-        bpf_events::pipe_log(ctx, e);
-    }
-}
-
 #[macro_export]
 macro_rules! log {
     ($ctx:expr, $msg:literal, $err:expr, $level:expr) => {{
@@ -83,21 +67,24 @@ macro_rules! log {
             const _PROBE_NAME: $crate::string::String<32> = $crate::probe_name!();
             const _MSG: $crate::string::String<64> = $crate::string::from_str_fitting($msg);
 
-            let args = $crate::errors::Args {
-                line: core::line!(),
-                location: _PROBE_NAME,
-                message: {
+            let _ = LOGS.insert(&0, &(*(EMPTY_LOG.as_ptr() as *const LogEvent)), 0);
+            if let Some(e) = LOGS.get_ptr_mut(&0) {
+                let e = &mut *e;
+                e.init_with_level($level);
+                e.info.etype = $crate::bpf_events::Type::Log;
+                e.data.location.clone_from(&_PROBE_NAME);
+                e.data.line = core::line!();
+                e.data.error = $err;
+                e.data.message = {
                     if !$msg.is_empty() {
                         $crate::option::BpfOption::Some(_MSG)
                     } else {
                         $crate::option::BpfOption::None
                     }
-                },
-                err: $err,
-                level: $level,
-            };
+                };
 
-            $crate::errors::log_with_args($ctx, &args);
+                $crate::bpf_events::pipe_log($ctx, e);
+            }
         };
     }};
 }

--- a/kunai-common/src/kprobe.rs
+++ b/kunai-common/src/kprobe.rs
@@ -7,6 +7,7 @@ mod bpf;
 #[cfg(target_arch = "bpf")]
 pub use bpf::*;
 
+#[repr(C)]
 #[derive(BpfError, Clone, Copy)]
 pub enum Error {
     #[error("failed to insert ctx")]

--- a/kunai-common/src/lib.rs
+++ b/kunai-common/src/lib.rs
@@ -1,6 +1,9 @@
 #![deny(unused_imports)]
 #![cfg_attr(target_arch = "bpf", no_std)]
-#![cfg_attr(target_arch = "bpf", allow(static_mut_refs, clippy::missing_safety_doc))]
+#![cfg_attr(
+    target_arch = "bpf",
+    allow(static_mut_refs, clippy::missing_safety_doc)
+)]
 
 pub mod macros;
 

--- a/kunai-common/src/lib.rs
+++ b/kunai-common/src/lib.rs
@@ -34,3 +34,5 @@ pub mod config;
 pub mod version;
 
 pub mod io_uring;
+
+pub mod option;

--- a/kunai-common/src/option.rs
+++ b/kunai-common/src/option.rs
@@ -1,0 +1,95 @@
+#[repr(C)]
+#[derive(Debug, Default)]
+pub enum BpfOption<T> {
+    Some(T),
+    #[default]
+    None,
+}
+
+impl<T> From<Option<T>> for BpfOption<T> {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(t) => Self::Some(t),
+            None => Self::None,
+        }
+    }
+}
+
+impl<T> From<BpfOption<T>> for Option<T> {
+    fn from(value: BpfOption<T>) -> Self {
+        match value {
+            BpfOption::Some(t) => Some(t),
+            BpfOption::None => None,
+        }
+    }
+}
+
+impl<T> Clone for BpfOption<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        self.as_ref().map(|t| t.clone())
+    }
+}
+
+impl<T> Copy for BpfOption<T> where T: Copy {}
+
+impl<T> PartialEq for BpfOption<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Some(a), Self::Some(b)) => a == b,
+            (Self::None, Self::None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl<T> Eq for BpfOption<T> where T: Eq {}
+
+impl<T> BpfOption<T> {
+    #[inline]
+    pub fn map<U, F>(self, f: F) -> BpfOption<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            BpfOption::Some(t) => BpfOption::Some(f(t)),
+            BpfOption::None => BpfOption::None,
+        }
+    }
+
+    #[inline]
+    pub const fn as_ref(&self) -> BpfOption<&T> {
+        match self {
+            BpfOption::Some(t) => BpfOption::Some(t),
+            BpfOption::None => BpfOption::None,
+        }
+    }
+
+    #[inline]
+    pub const fn as_mut(&mut self) -> BpfOption<&mut T> {
+        match self {
+            BpfOption::Some(t) => BpfOption::Some(t),
+            BpfOption::None => BpfOption::None,
+        }
+    }
+
+    #[inline]
+    pub fn into_opt(self) -> Option<T> {
+        self.into()
+    }
+
+    pub fn unwrap_or_default(self) -> T
+    where
+        T: Default,
+    {
+        match self {
+            BpfOption::Some(t) => t,
+            BpfOption::None => T::default(),
+        }
+    }
+}

--- a/kunai-common/src/path.rs
+++ b/kunai-common/src/path.rs
@@ -1,4 +1,4 @@
-use crate::errors::ProbeError;
+use crate::{errors::ProbeError, option::BpfOption};
 
 use super::time::Time;
 
@@ -157,22 +157,22 @@ pub struct Path {
     depth: u16,
     real: bool, // flag if path is a realpath
     pub hash: u64,
-    pub metadata: Option<Metadata>,
+    pub metadata: BpfOption<Metadata>,
     pub mode: Mode,
-    pub error: Option<Error>,
+    pub error: BpfOption<Error>,
 }
 
 impl PartialEq for Path {
     fn eq(&self, other: &Self) -> bool {
         let meta_eq = match (self.metadata, other.metadata) {
-            (Some(sm), Some(om)) => {
+            (BpfOption::Some(sm), BpfOption::Some(om)) => {
                 sm.ino == om.ino
                     && sm.sb_ino == om.sb_ino
                     && sm.size == om.size
                     && sm.mtime == om.mtime
                     && sm.ctime == om.ctime
             }
-            (None, None) => true,
+            (BpfOption::None, BpfOption::None) => true,
             _ => false,
         };
 
@@ -193,9 +193,9 @@ impl Default for Path {
             depth: 0,
             hash: 0,
             real: false,
-            metadata: None,
+            metadata: BpfOption::None,
             mode: Mode::Append,
-            error: None,
+            error: BpfOption::None,
         }
     }
 }
@@ -217,7 +217,7 @@ impl Path {
 
         self.len = 0;
         self.mode = mode;
-        self.error = None;
+        self.error = BpfOption::None;
 
         let mut start = 0;
         if matches!(mode, Mode::Prepend) {
@@ -228,7 +228,7 @@ impl Path {
         self.len = n as u32;
 
         if src.len() > self.buffer.len() {
-            self.error = Some(Error::TruncPath);
+            self.error = BpfOption::Some(Error::TruncPath);
             return Err(n);
         }
 

--- a/kunai-common/src/path/bpf.rs
+++ b/kunai-common/src/path/bpf.rs
@@ -1,8 +1,13 @@
-use crate::co_re::{self, core_read_kernel};
+use crate::{
+    co_re::{self, core_read_kernel},
+    option::BpfOption,
+    path::Metadata,
+    time::Time,
+};
 use aya_ebpf::check_bounds_signed;
 use aya_ebpf::helpers::gen;
 
-use super::{Error, Metadata, Mode, Path, MAX_NAME, MAX_PATH_LEN};
+use super::{Error, Mode, Path, MAX_NAME, MAX_PATH_LEN};
 
 type Result<T> = core::result::Result<T, Error>;
 
@@ -17,19 +22,24 @@ fn xor_shift_star(a: u64, b: u64) -> u64 {
 impl Path {
     #[inline(always)]
     unsafe fn init_from_inode(&mut self, i: &co_re::inode) -> Result<()> {
-        let atime = core_read_kernel!(i, i_atime).ok_or(Error::DentryAtime)?;
-        let ctime = core_read_kernel!(i, i_ctime).ok_or(Error::DentryCtime)?;
-        let mtime = core_read_kernel!(i, i_mtime).ok_or(Error::DentryMtime)?;
+        // weird initialization pattern but it prevent raising stack size issue
+        self.metadata = BpfOption::Some(Metadata::default());
 
-        self.metadata = Some(Metadata {
-            ino: core_read_kernel!(i, i_ino).ok_or(Error::PathInoFailure)?,
-            sb_ino: core_read_kernel!(i, i_sb, s_root, d_inode, i_ino)
-                .ok_or(Error::PathSbInoFailure)?,
-            size: core_read_kernel!(i, i_size).ok_or(Error::InodeIsize)?,
-            atime: atime.into(),
-            ctime: ctime.into(),
-            mtime: mtime.into(),
-        });
+        if let BpfOption::Some(m) = self.metadata.as_mut() {
+            m.ino = core_read_kernel!(i, i_ino).ok_or(Error::PathInoFailure)?;
+            m.sb_ino = core_read_kernel!(i, i_sb, s_root, d_inode, i_ino)
+                .ok_or(Error::PathSbInoFailure)?;
+            m.size = core_read_kernel!(i, i_size).ok_or(Error::InodeIsize)?;
+            m.atime = core_read_kernel!(i, i_atime)
+                .ok_or(Error::DentryAtime)
+                .map(Time::from)?;
+            m.ctime = core_read_kernel!(i, i_ctime)
+                .ok_or(Error::DentryCtime)
+                .map(Time::from)?;
+            m.mtime = core_read_kernel!(i, i_mtime)
+                .ok_or(Error::DentryMtime)
+                .map(Time::from)?;
+        }
 
         Ok(())
     }
@@ -47,7 +57,7 @@ impl Path {
         match self.inner_resolve(p, max_depth) {
             Ok(()) => Ok(()),
             Err(e) => {
-                self.error = Some(e);
+                self.error = BpfOption::Some(e);
                 Err(e)
             }
         }

--- a/kunai-ebpf/src/probes/bpf.rs
+++ b/kunai-ebpf/src/probes/bpf.rs
@@ -3,6 +3,7 @@ use aya_ebpf::{
     maps::LruHashMap,
     programs::{ProbeContext, RetProbeContext},
 };
+use kunai_common::option::BpfOption;
 
 #[map]
 static mut BPF_PROG_TRACK: LruHashMap<u64, co_re::bpf_prog> = LruHashMap::with_max_entries(1024, 0);
@@ -90,7 +91,7 @@ unsafe fn try_bpf_prog_load(ctx: &RetProbeContext) -> ProbeResult<()> {
         // needs to be implemented like that not to cause a read_ok! verifier error
         // on some kernels
         if let Some(vi) = bpf_prog_aux.verified_insns() {
-            event.data.verified_insns = Some(vi)
+            event.data.verified_insns = BpfOption::Some(vi)
         }
 
         // get attached_func_name

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -39,6 +39,7 @@ use kunai_common::bpf_events::{
 };
 use kunai_common::config::Filter;
 use kunai_common::io_uring::io_uring_op;
+use kunai_common::option::BpfOption;
 use kunai_common::{inspect_err, kernel};
 
 use kunai::util::namespace::{Mnt, Namespace};
@@ -861,7 +862,7 @@ impl EventConsumer<'_> {
 
     #[inline(always)]
     fn mnt_ns_from_task(ti: &bpf_events::TaskInfo) -> Option<Mnt> {
-        ti.namespaces.map(|ns| Mnt::from_inum(ns.mnt))
+        ti.namespaces.map(|ns| Mnt::from_inum(ns.mnt)).into()
     }
 
     #[inline(always)]
@@ -1183,11 +1184,11 @@ impl EventConsumer<'_> {
                 sha512: "?".into(),
                 size: 0,
             },
-            verified_insns: bpf_data.verified_insns,
+            verified_insns: bpf_data.verified_insns.into(),
             loaded: bpf_data.loaded,
         };
 
-        if let Some(h) = &bpf_data.hashes {
+        if let BpfOption::Some(h) = &bpf_data.hashes {
             data.bpf_prog.md5 = h.md5.into();
             data.bpf_prog.sha1 = h.sha1.into();
             data.bpf_prog.sha256 = h.sha256.into();
@@ -1602,8 +1603,8 @@ impl EventConsumer<'_> {
         // we encountered some cgroup parsing error in eBPF
         // so we need to resolve cgroup in userland
         let cgroups = match cgroup.error {
-            None => vec![cgroup.to_string()],
-            Some(_) => {
+            BpfOption::None => vec![cgroup.to_string()],
+            BpfOption::Some(_) => {
                 if let Ok(cgroups) =
                     procfs::process::Process::new(info.task_info().pid).and_then(|p| p.cgroups())
                 {
@@ -2409,7 +2410,7 @@ impl EventProducer {
                             size: insns.len(),
                         };
 
-                        e.data.hashes = Some(h);
+                        e.data.hashes = BpfOption::Some(h);
                     }
 
                     Err(err) => {

--- a/kunai/src/cache.rs
+++ b/kunai/src/cache.rs
@@ -235,7 +235,7 @@ impl From<&kunai_common::path::Path> for Path {
     fn from(value: &kunai_common::path::Path) -> Self {
         Self::Bpf {
             path: value.to_path_buf(),
-            ebpf_meta: value.metadata,
+            ebpf_meta: value.metadata.into(),
         }
     }
 }

--- a/kunai/src/events.rs
+++ b/kunai/src/events.rs
@@ -121,7 +121,7 @@ impl TaskSection {
             user: add.user.map(|u| u.name).unwrap_or("?".into()),
             gid: ti.gid,
             group: add.group.map(|g| g.name).unwrap_or("?".into()),
-            namespaces: ti.namespaces.map(|ns| ns.into()),
+            namespaces: ti.namespaces.map(|ns| ns.into()).into(),
             flags: ti.flags,
             zombie: ti.zombie,
         }

--- a/kunai/src/events/agent.rs
+++ b/kunai/src/events/agent.rs
@@ -2,6 +2,7 @@ use std::{ffi::OsString, io};
 
 use kunai_common::{
     bpf_events::{self, TaskInfo, Type, COMM_SIZE},
+    option::BpfOption,
     uuid::ProcUuid,
 };
 use thiserror::Error;
@@ -57,7 +58,7 @@ impl AgentEventInfo {
             uid: status.euid,
             gid: status.egid,
             tg_uuid: ProcUuid::new(start_time, 0, status.tgid as u32),
-            namespaces: Some(bpf_events::Namespaces {
+            namespaces: BpfOption::Some(bpf_events::Namespaces {
                 mnt: mnt.identifier as u32,
             }),
             comm,


### PR DESCRIPTION
**Summary**
Fixes a bug where `std::option::Option` (lacking `#[repr(C)]`) was used in shared eBPF/userspace structures, causing undefined behavior and potential crashes due to incompatible memory layouts across FFI boundaries. The issue is described here: https://github.com/rust-lang/rust/issues/155934

**Motivation**
Option has extremely limited stable ABI guarantees for an enumerated list of types (Box, references, num::NonZero, ptr::NonNull). When used in structs shared between eBPF and userspace via memory maps, differing memory representations can corrupt data reads, leading to silent bugs or application crashes. The Aya/BPF ecosystem requires `#[repr(C)]` types for all shared data structures.

**Changes**
- Introduce `BpfOption<T>` — a `#[repr(C)]` enum mirroring `Option<T>` semantics with `Some(T)`/`None` variants
- Replace all `Option<T>` fields in shared structs (`TaskInfo`, `Cgroup`, `Path`, `BpfProgData`, `LogData`, `Args`, etc.) with `BpfOption<T>`
- Add `From<Option<T>>` and `From<BpfOption<T>>` implementations for seamless conversion
- Add `#[repr(C)]` to error enums used in shared contexts (`alloc::Error`, `buffer::Error`, `kprobe::Error`, `cgroup::Error`)

**Breaking Changes**
None for public APIs. Internal eBPF event structs now use `BpfOption<T>` instead of `Option<T>`.

**Testing**
- Build passes with `cargo build`
- All existing unit tests pass
- eBPF probes compile and load correctly
- Event serialization/deserialization verified

**Notes**
The issue stems from Rust's unstable ABI: `Option` may have different representations across compilation units or targets. This fix follows Aya's recommendation to use only `#[repr(C)]` types in shared memory. The `BpfOption` type provides the same API surface as `Option` with conversions for interoperability.
