### PR TITLE
fix: correct bio_vec parsing and arch-aware page

### DIFF
--- a/kunai-common/src/buffer.rs
+++ b/kunai-common/src/buffer.rs
@@ -133,8 +133,12 @@ pub enum Error {
     BvecOffsetMissing,
     #[error("bio_vec.bv_len missing")]
     BvecLenMissing,
+    #[error("bio_vec base is null")]
+    BvecNullBase,
     #[error("failed to read bio_vec")]
     FailedToReadBioVec,
+    #[error("Unsupported target arch")]
+    UnsupportedArch,
 }
 
 impl From<Error> for ProbeError {

--- a/kunai-common/src/buffer/bpf.rs
+++ b/kunai-common/src/buffer/bpf.rs
@@ -1,6 +1,7 @@
 use core::cmp::min;
 
 use crate::co_re::{bio_vec, iov_iter, iovec};
+use crate::utils::verifier_clamp;
 use aya_ebpf::check_bounds_signed;
 use aya_ebpf::helpers::{gen, *};
 
@@ -11,7 +12,6 @@ impl<const N: usize> Buffer<N> {
     pub unsafe fn fill_from_iov_iter<const MAX_NR_SEGS: usize>(
         &mut self,
         iter: iov_iter,
-        count: Option<usize>,
     ) -> Result<(), Error> {
         let nr_segs = iter.nr_segs().ok_or(Error::NrSegsMissing)? as usize;
 
@@ -33,7 +33,7 @@ impl<const N: usize> Buffer<N> {
                 if self.is_full() || i >= nr_segs {
                     break;
                 }
-                self.append_iov(iov.get(i), count)?;
+                self.append_iov(iov.get(i))?;
             }
         } else if iter.is_iter_bvec() {
             let bvec = iter.bvec().ok_or(Error::BvecMissing)?;
@@ -42,7 +42,7 @@ impl<const N: usize> Buffer<N> {
                 if self.is_full() || i >= nr_segs {
                     break;
                 }
-                self.append_bio_vec(bvec.get(i), count)?;
+                self.append_bio_vec(bvec.get(i))?;
             }
         } else {
             return Err(Error::UnimplementedIter);
@@ -52,43 +52,19 @@ impl<const N: usize> Buffer<N> {
     }
 
     #[inline(always)]
-    unsafe fn append_iov(&mut self, iov: iovec, count: Option<usize>) -> Result<(), Error> {
+    unsafe fn append_iov(&mut self, iov: iovec) -> Result<(), Error> {
         let iov_len = iov.iov_len().ok_or(Error::IovLenMissing)?;
         let iov_base = iov.iov_base().ok_or(Error::IovBaseMissing)?;
 
-        // our offset is at current len to append
-        let offset = self.len as i64;
+        let size = min(iov_len as i64, self.space_left() as i64);
 
-        let mut size = iov_len as i64;
+        // verifier massage: offset can never be greater than buf capacity
+        let offset = verifier_clamp(self.len() as i64, 0, N as i64) as usize;
 
-        if let Some(count) = count {
-            size = min(count as i64, size);
-        }
-
-        let left = N as i64 - offset;
-        if size > left {
-            return Err(Error::BufferFull);
-        }
-
-        // we check map access is not OOB
-        if !check_bounds_signed(offset, 0, N as i64) {
-            return Ok(());
-        }
-
-        // we check we will not write OOB
-        if !check_bounds_signed(size, 0, N as i64) {
-            return Ok(());
-        }
-
-        if let Some(dst) = self
-            .buf
-            // we need to clamp as we cast offset and bounds might be lost by verifier
-            .get_mut((offset as usize).clamp(0, N)..N)
-            .map(|d| d.as_mut_ptr())
-        {
+        if let Some(dst) = self.buf.get_mut(offset..N).map(|d| d.as_mut_ptr()) {
             if gen::bpf_probe_read_user(
                 dst as *mut _,
-                (size as u32).clamp(0, N as u32),
+                verifier_clamp(size, 0, N as i64) as u32,
                 iov_base as *const _,
             ) < 0
             {
@@ -96,67 +72,42 @@ impl<const N: usize> Buffer<N> {
             }
 
             self.len += size as usize;
-            Ok(())
-        } else {
-            // this path should never be taken as we
-            // bound checked everything upstream
-            Err(Error::ShouldNotHappen)
         }
+        Ok(())
     }
 
     #[inline(always)]
-    unsafe fn append_bio_vec(&mut self, bvec: bio_vec, count: Option<usize>) -> Result<(), Error> {
+    unsafe fn append_bio_vec(&mut self, bvec: bio_vec) -> Result<(), Error> {
         let page = bvec.bv_page().ok_or(Error::BvecPageMissing)?;
-        let bv_offset = bvec.bv_len().ok_or(Error::BvecOffsetMissing)?;
+        let bv_offset = bvec.bv_offset().ok_or(Error::BvecOffsetMissing)?;
         let bv_len = bvec.bv_len().ok_or(Error::BvecLenMissing)?;
 
-        let bvec_base = (page.to_va() as u64).wrapping_add(bv_offset as u64);
+        let bvec_data = if let Some(pa) = page.page_to_virt() {
+            if pa.is_null() {
+                return Err(Error::BvecNullBase);
+            }
+            pa.byte_offset(bv_offset as isize)
+        } else {
+            return Err(Error::UnsupportedArch);
+        };
 
-        // our offset is at current len to append
-        let offset = self.len as i64;
-        let mut size = bv_len as i64;
+        let size = min(self.space_left() as i64, bv_len as i64);
 
-        if let Some(count) = count {
-            size = min(count as i64, size);
-        }
+        let offset = verifier_clamp(self.len() as i64, 0, N as i64) as usize;
 
-        let left = N as i64 - offset;
-        if size > left {
-            return Err(Error::BufferFull);
-        }
-
-        // we check map access is not OOB
-        if !check_bounds_signed(offset, 0, N as i64) {
-            return Ok(());
-        }
-
-        // we check we will not write OOB
-        if !check_bounds_signed(size, 0, N as i64) {
-            return Ok(());
-        }
-
-        if let Some(dst) = self
-            .buf
-            // we need to clamp as we cast offset and bounds might be lost by verifier
-            .get_mut((offset as usize).clamp(0, N)..N)
-            .map(|d| d.as_mut_ptr())
-        {
+        if let Some(dst) = self.buf.get_mut(offset..N).map(|d| d.as_mut_ptr()) {
             if gen::bpf_probe_read_kernel(
                 dst as *mut _,
-                (size as u32).clamp(0, N as u32),
-                bvec_base as *const _,
+                verifier_clamp(size, 0, N as i64) as u32,
+                bvec_data,
             ) < 0
             {
                 return Err(Error::FailedToReadBioVec);
             }
 
             self.len += size as usize;
-            Ok(())
-        } else {
-            // this path should never be taken as we
-            // bound checked everything upstream
-            Err(Error::ShouldNotHappen)
         }
+        Ok(())
     }
 
     #[inline(always)]

--- a/kunai-common/src/co_re/c/shim.c
+++ b/kunai-common/src/co_re/c/shim.c
@@ -91,6 +91,15 @@ Using anonymous structs seems to make the linking fail
 		return bpf_core_enum_value_exists(enum enum_type, enum_value);              \
 	}
 
+// Exposes the CO-RE-resolved size of a struct as shim_size_of_<struct>().
+// The returned value reflects the actual kernel struct size at runtime, not
+// the (potentially incomplete) definition in this file.
+#define SHIM_SIZE_OF(struc)                                          \
+	__attribute__((always_inline)) __u64 shim_size_of_##struc()      \
+	{                                                                \
+		return bpf_core_type_size(struct struc);                     \
+	}
+
 struct kgid_t
 {
 	gid_t val;
@@ -718,6 +727,8 @@ struct page
 {
 	long unsigned int flags;
 } __attribute__((preserve_access_index));
+
+SHIM_SIZE_OF(page);
 
 struct bio_vec
 {

--- a/kunai-common/src/co_re/core_iov.rs
+++ b/kunai-common/src/co_re/core_iov.rs
@@ -111,6 +111,7 @@ impl iov_iter {
     rust_shim_kernel_impl!(pub(self), _iov, iov_iter, iov, iovec);
     rust_shim_kernel_impl!(pub(self), ___iov, iov_iter, __iov, iovec);
 
+    #[inline(always)]
     fn is_iter_type(&self, ty: IterType) -> bool {
         if let Some(t) = unsafe { self.iter_type() } {
             return t == ty;

--- a/kunai-common/src/co_re/core_page.rs
+++ b/kunai-common/src/co_re/core_page.rs
@@ -1,6 +1,13 @@
-use aya_ebpf::cty::c_void;
+#![allow(unexpected_cfgs)]
 
-use super::{gen, CoRe};
+use aya_ebpf::cty::c_void;
+#[cfg(any(bpf_target_arch = "x86_64", bpf_target_arch = "aarch64"))]
+use aya_ebpf::helpers::bpf_probe_read_kernel;
+
+use super::{
+    gen::{self, shim_size_of_page},
+    CoRe,
+};
 use core::ptr;
 
 #[no_mangle]
@@ -9,21 +16,162 @@ static PAGE_SIZE: u64 = 0;
 #[no_mangle]
 static PAGE_SHIFT: u64 = 0;
 
+#[cfg(bpf_target_arch = "x86_64")]
+#[no_mangle]
+static VMEMMAP_BASE_PTR: u64 = 0;
+#[cfg(any(bpf_target_arch = "x86_64", bpf_target_arch = "aarch64"))]
+static mut VMEMMAP_BASE: u64 = 0;
+
+#[cfg(bpf_target_arch = "x86_64")]
+#[no_mangle]
+static PAGE_OFFSET_BASE_PTR: u64 = 0;
+#[cfg(any(bpf_target_arch = "x86_64", bpf_target_arch = "aarch64"))]
+static mut PAGE_OFFSET_BASE: u64 = 0;
+
+/// Returns the kernel page shift (i.e., `log2(page_size)`).
 #[inline(always)]
 pub fn page_shift() -> u64 {
     unsafe { ptr::read_volatile(&PAGE_SHIFT) }
 }
 
+/// Returns the kernel page size in bytes.
 #[inline(always)]
 pub fn page_size() -> u64 {
     unsafe { ptr::read_volatile(&PAGE_SIZE) }
 }
 
+#[cfg(bpf_target_arch = "x86_64")]
+#[inline(always)]
+fn vmemmap_base() -> u64 {
+    unsafe {
+        if VMEMMAP_BASE == 0 {
+            let addr = ptr::read_volatile(&VMEMMAP_BASE_PTR) as *const u64;
+            VMEMMAP_BASE = bpf_probe_read_kernel(addr).unwrap_or(0);
+        }
+        VMEMMAP_BASE
+    }
+}
+
+#[cfg(bpf_target_arch = "x86_64")]
+#[inline(always)]
+fn page_offset_base() -> u64 {
+    unsafe {
+        if PAGE_OFFSET_BASE == 0 {
+            let addr = ptr::read_volatile(&PAGE_OFFSET_BASE_PTR) as *const u64;
+            PAGE_OFFSET_BASE = bpf_probe_read_kernel(addr).unwrap_or(0);
+        }
+        PAGE_OFFSET_BASE
+    }
+}
+
+#[cfg(bpf_target_arch = "aarch64")]
+#[inline(always)]
+fn mem_layout_aarch64(page_ptr: u64) -> (u64, u64) {
+    unsafe {
+        if PAGE_OFFSET_BASE == 0 || PAGE_OFFSET_BASE == 0 {
+            (VMEMMAP_BASE, PAGE_OFFSET_BASE) =
+                find_mem_layout_aarch64(page_ptr).unwrap_or_default();
+        }
+        (VMEMMAP_BASE, PAGE_OFFSET_BASE)
+    }
+}
+
+#[cfg(bpf_target_arch = "aarch64")]
+#[inline(always)]
+fn is_kernel_memory_readable<T>(addr: u64) -> bool {
+    unsafe { bpf_probe_read_kernel(addr as *const T).is_ok() }
+}
+
+#[cfg(bpf_target_arch = "aarch64")]
+const ARM64_LAYOUT_CANDIDATES: &[(u64, u64)] = &[
+    // (VMEMMAP_START, PAGE_OFFSET)
+
+    // 4K pages, 48-bit VA
+    (0xfffffc0000000000, 0xffff000000000000),
+    // 64K pages, 52-bit VA
+    (0xfffffc0000000000, 0xfff0000000000000),
+];
+
+#[cfg(bpf_target_arch = "aarch64")]
+#[inline(always)]
+fn is_page_readable(virt: u64) -> bool {
+    let page_sz = 1u64 << page_shift();
+
+    is_kernel_memory_readable::<u64>(virt)
+        && is_kernel_memory_readable::<u64>(virt.wrapping_add(page_sz >> 1))
+        && is_kernel_memory_readable::<u64>(
+            virt.wrapping_add(page_sz - core::mem::size_of::<u64>() as u64),
+        )
+}
+
+/// Infers `(VMEMMAP_START, PAGE_OFFSET)` from a known `struct page` pointer.
+///
+/// Iterates over known aarch64 layout candidates and returns the first pair
+/// whose derived virtual address is readable via `bpf_probe_read_kernel`.
+/// Returns `None` if no candidate matches.
+#[cfg(bpf_target_arch = "aarch64")]
+#[inline(always)]
+fn find_mem_layout_aarch64(page_ptr: u64) -> Option<(u64, u64)> {
+    let struct_page_size = page::size_of();
+    let shift = page_shift();
+
+    for &(vmemmap_start, page_offset) in ARM64_LAYOUT_CANDIDATES {
+        if page_ptr >= vmemmap_start {
+            let idx = page_ptr.wrapping_sub(vmemmap_start) / struct_page_size;
+            let virt = page_offset.wrapping_add(idx << shift);
+
+            if is_page_readable(virt) {
+                return Some((vmemmap_start, page_offset));
+            }
+        }
+    }
+
+    None
+}
+
+/// BPF CO-RE wrapper for the kernel `struct page`.
 #[allow(non_camel_case_types)]
 pub type page = CoRe<gen::page>;
 
 impl page {
-    pub fn to_va(&self) -> *const c_void {
-        ((self.as_ptr() as u64 / page_size()) << page_shift()) as *const _
+    /// Returns the size of `struct page` as reported by the kernel via CO-RE.
+    #[inline(always)]
+    pub fn size_of() -> u64 {
+        unsafe { shim_size_of_page() }
+    }
+
+    /// Converts this `struct page` pointer to its virtual address.
+    ///
+    /// Returns a null pointer on unsupported architectures.
+    pub fn page_to_virt(&self) -> Option<*const c_void> {
+        cfg_select! {
+           bpf_target_arch = "x86_64" => Some(self.page_to_virt_x86_64()),
+           bpf_target_arch = "aarch64" => Some(self.page_to_virt_aarch64()),
+           _ => None
+        }
+    }
+
+    #[cfg(bpf_target_arch = "x86_64")]
+    #[inline(always)]
+    fn page_to_virt_x86_64(&self) -> *const c_void {
+        let vmemmap = vmemmap_base();
+        let page_offset = page_offset_base();
+
+        self._page_to_virt(vmemmap, page_offset)
+    }
+
+    #[cfg(bpf_target_arch = "aarch64")]
+    #[inline(always)]
+    fn page_to_virt_aarch64(&self) -> *const c_void {
+        let (vmemmap, page_offset) = mem_layout_aarch64(self.as_ptr() as u64);
+
+        self._page_to_virt(vmemmap, page_offset)
+    }
+
+    #[inline(always)]
+    fn _page_to_virt(&self, vmemmap: u64, page_offset: u64) -> *const c_void {
+        let pfn = (self.as_ptr() as u64).wrapping_sub(vmemmap) / page::size_of();
+        let phys = pfn << page_shift();
+        phys.wrapping_add(page_offset) as *const c_void
     }
 }

--- a/kunai-common/src/co_re/gen.rs
+++ b/kunai-common/src/co_re/gen.rs
@@ -1721,6 +1721,9 @@ unsafe extern "C" {
 pub struct page {
     pub flags: ::core::ffi::c_ulong,
 }
+unsafe extern "C" {
+    pub fn shim_size_of_page() -> __u64;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct bio_vec {

--- a/kunai-common/src/lib.rs
+++ b/kunai-common/src/lib.rs
@@ -4,6 +4,7 @@
     target_arch = "bpf",
     allow(static_mut_refs, clippy::missing_safety_doc)
 )]
+#![cfg_attr(target_arch = "bpf", feature(asm_experimental_arch))]
 
 pub mod macros;
 

--- a/kunai-common/src/utils/bpf.rs
+++ b/kunai-common/src/utils/bpf.rs
@@ -4,3 +4,26 @@ use aya_ebpf::helpers::bpf_get_current_pid_tgid;
 pub fn bpf_task_tracking_id() -> u64 {
     bpf_get_current_pid_tgid()
 }
+
+/// Clamp `value` to `[lower, upper]` in a form the BPF verifier can follow.
+///
+/// The standard Rust `.clamp()` may be optimised away entirely by the compiler
+/// when it can prove the value is already in range. Using inline assembly prevents
+/// the compiler from eliminating the branches, so the verifier always observes them.
+///
+/// **`lower` and `upper` must be compile-time constants.**
+#[inline(always)]
+pub fn verifier_clamp(mut value: i64, lower: i64, upper: i64) -> i64 {
+    unsafe {
+        core::arch::asm!(
+            "if {value} s> {lower} goto +1", // if value > lower, skip the floor clamp
+            "{value} = {lower}",
+            "if {value} s< {upper} goto +1", // if value < upper, skip the ceiling clamp
+            "{value} = {upper}",
+            value = inout(reg) value,
+            lower = in(reg) lower,
+            upper = in(reg) upper,
+        );
+        value
+    }
+}

--- a/kunai-ebpf/src/probes/send_data.rs
+++ b/kunai-ebpf/src/probes/send_data.rs
@@ -9,7 +9,9 @@ use super::*;
 use aya_ebpf::programs::ProbeContext;
 use kunai_common::{
     buffer::Buffer,
+    kernel,
     net::{SaFamily, SockAddr, SocketInfo},
+    version::kernel_version,
 };
 
 /// match-proto:v5.0:security/security.c:int security_socket_sendmsg(struct socket *sock, struct msghdr *msg, int size)
@@ -75,7 +77,15 @@ unsafe fn try_sock_send_data(ctx: &ProbeContext) -> ProbeResult<()> {
     let src_ip_port = SockAddr::src_from_sock_common(sk_common)?;
 
     let iov_iter = core_read_kernel!(pmsg, msg_iter)?;
-    if let Err(e) = iov_buf.fill_from_iov_iter::<128>(iov_iter, None) {
+
+    let res = if kernel_version() < kernel!(5, 5, 0) {
+        // verifier trips with program too large in 5.4
+        iov_buf.fill_from_iov_iter::<96>(iov_iter)
+    } else {
+        iov_buf.fill_from_iov_iter::<128>(iov_iter)
+    };
+
+    if let Err(e) = res {
         match e {
             // buffer full is not a bad error it just tell we have no more space in our buffer
             kunai_common::buffer::Error::BufferFull => {}

--- a/kunai/src/bin/main.rs
+++ b/kunai/src/bin/main.rs
@@ -25,6 +25,7 @@ use kunai::events::{
 use kunai::events::{IoUringOp, IoUringSqeData, StartData};
 use kunai::info::{AdditionalInfo, ProcKey, StdEventInfo, TaskAdditionalInfo};
 use kunai::ioc::IoC;
+use kunai::kallsyms::KernelSymbols;
 use kunai::util::uname::Utsname;
 use kunai::util::uptime::Uptime;
 use kunai::util::{
@@ -3513,6 +3514,9 @@ impl Command {
         setrlimit(RLIMIT_MEMLOCK, rlimit)
             .map_err(|e| anyhow!("failed to set RLIMIT_MEMLOCK: {e}"))?;
 
+        let kernel_syms = KernelSymbols::from_sys()
+            .map_err(|e| anyhow!("failed to build kernel symbols: {e}"))?;
+
         // checks on harden mode
         if conf.harden {
             if current_kernel < kernel!(5, 7, 0) {
@@ -3608,7 +3612,7 @@ impl Command {
                 loop {
                     info!("Starting event producer");
                     // we start producer
-                    let mut bpf = kunai::prepare_bpf(current_kernel, &conf, vll)?;
+                    let mut bpf = kunai::prepare_bpf(current_kernel, &kernel_syms, &conf, vll)?;
                     let mut prod =
                         EventProducer::with_params(&mut bpf, conf.clone(), sender.clone())?;
 
@@ -3624,7 +3628,7 @@ impl Command {
                     let arc_prod = prod.produce().await;
 
                     // we load and attach bpf programs
-                    kunai::load_and_attach_bpf(&conf, current_kernel, &mut bpf)?;
+                    kunai::load_and_attach_bpf(&conf, &kernel_syms, current_kernel, &mut bpf)?;
 
                     loop {
                         // block make sure lock is dropped before sleeping

--- a/kunai/src/kallsyms.rs
+++ b/kunai/src/kallsyms.rs
@@ -1,0 +1,253 @@
+use std::{
+    collections::HashMap,
+    fs,
+    io::{self, BufRead},
+    num::ParseIntError,
+};
+
+use thiserror::Error;
+
+const KALLSYMS_PATH: &str = "/proc/kallsyms";
+const KPTR_RESTRICT: &str = "/proc/sys/kernel/kptr_restrict";
+
+/// Error type for [`KernelSymbols`] operations.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("{0}")]
+    Io(#[from] io::Error),
+    #[error("{0}")]
+    ParseEntry(#[from] ParseEntryError),
+}
+
+#[derive(Debug)]
+enum SymbolKind {
+    Data,
+    Text,
+    Unused,
+}
+
+#[derive(Debug)]
+struct SymbolEntry {
+    address: u64,
+    kind: SymbolKind,
+    name: String,
+}
+
+/// Error returned when a `/proc/kallsyms` line cannot be parsed.
+#[derive(Debug, Error)]
+pub enum ParseEntryError {
+    #[error("{0}")]
+    Address(#[from] ParseIntError),
+    #[error("empty symbol name")]
+    EmptySymName,
+}
+
+impl SymbolEntry {
+    fn from_line(line: String) -> Result<Self, ParseEntryError> {
+        let mut parts = line.splitn(3, ' ');
+        let address = u64::from_str_radix(parts.next().unwrap_or(""), 16)?;
+        let kind = match parts.next().unwrap_or("") {
+            "t" | "T" => SymbolKind::Text,
+            "d" | "D" => SymbolKind::Data,
+            _ => SymbolKind::Unused,
+        };
+
+        let Some(name) = parts.next().map(String::from) else {
+            return Err(ParseEntryError::EmptySymName);
+        };
+
+        Ok(Self {
+            address,
+            kind,
+            name,
+        })
+    }
+}
+
+/// Parsed view of kernel symbols from `/proc/kallsyms`.
+///
+/// Symbols are split into text (`T`/`t`) and data (`D`/`d`) categories.
+/// When multiple symbols share a name, only the first address is returned
+/// by the lookup methods.
+#[derive(Debug, Default)]
+pub struct KernelSymbols {
+    text: HashMap<String, Vec<u64>>,
+    data: HashMap<String, Vec<u64>>,
+}
+
+impl KernelSymbols {
+    /// Loads kernel symbols from `/proc/kallsyms`.
+    ///
+    /// Temporarily sets `kptr_restrict` to `1` so that privileged callers
+    /// can read non-zero addresses, then restores the original value.
+    pub fn from_sys() -> Result<Self, Error> {
+        let opt_kptr_restrict_bak = if fs::exists(KPTR_RESTRICT).unwrap_or_default() {
+            let v = fs::read_to_string(KPTR_RESTRICT)
+                .map_err(|e| io::Error::other(format!("cannot read {KPTR_RESTRICT}: {e}")))?;
+
+            // we allow privileged user to see kernel addresses
+            fs::write(KPTR_RESTRICT, "1")
+                .map_err(|e| io::Error::other(format!("cannot set {KPTR_RESTRICT}: {e}")))?;
+
+            Some(v)
+        } else {
+            None
+        };
+
+        let f = fs::File::open(KALLSYMS_PATH)
+            .map_err(|e| io::Error::other(format!("cannot open {KALLSYMS_PATH}: {e}")))?;
+        let result = KernelSymbols::from_reader(f);
+
+        if let Some(kptr_restrict_bak) = opt_kptr_restrict_bak {
+            // restore regardless of whether reading succeeded
+            fs::write(KPTR_RESTRICT, &kptr_restrict_bak)
+                .map_err(|e| io::Error::other(format!("cannot restore {KPTR_RESTRICT}: {e}")))?;
+        }
+
+        result
+    }
+
+    /// Parses kernel symbols from a reader in `/proc/kallsyms` format.
+    #[inline]
+    pub fn from_reader<R: io::Read>(r: R) -> Result<Self, Error> {
+        let mut ks = KernelSymbols::new();
+        let br = io::BufReader::new(r);
+        for line in br.lines() {
+            ks.add_symbol(SymbolEntry::from_line(line?)?);
+        }
+        Ok(ks)
+    }
+
+    fn new() -> Self {
+        Default::default()
+    }
+
+    fn add_symbol(&mut self, sym: SymbolEntry) {
+        match &sym.kind {
+            SymbolKind::Text => {
+                self.text
+                    .entry(sym.name)
+                    .and_modify(|a| a.push(sym.address))
+                    .or_insert_with(|| vec![sym.address]);
+            }
+            SymbolKind::Data => {
+                self.data
+                    .entry(sym.name)
+                    .and_modify(|a| a.push(sym.address))
+                    .or_insert_with(|| vec![sym.address]);
+            }
+            SymbolKind::Unused => {}
+        };
+    }
+
+    /// Returns `true` if a text symbol with the given name exists.
+    #[inline(always)]
+    pub fn contains_text_symbol(&self, name: &str) -> bool {
+        self.text.contains_key(name)
+    }
+
+    /// Returns the address of the first text symbol matching `name`.
+    pub fn get_text_symbol_addr(&self, name: &str) -> Option<u64> {
+        self.text.get(name).and_then(|addrs| addrs.first().cloned())
+    }
+
+    /// Returns the address of the first data symbol matching `name`.
+    pub fn get_data_symbol_addr(&self, name: &str) -> Option<u64> {
+        self.data.get(name).and_then(|addrs| addrs.first().cloned())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn ks_from_str(s: &str) -> KernelSymbols {
+        KernelSymbols::from_reader(s.as_bytes()).expect("failed to parse")
+    }
+
+    #[test]
+    fn text_symbol_found() {
+        let ks = ks_from_str("fffffff812345678 T my_func\n");
+        assert!(ks.contains_text_symbol("my_func"));
+        assert_eq!(ks.get_text_symbol_addr("my_func"), Some(0xfffffff812345678));
+    }
+
+    #[test]
+    fn local_text_symbol_found() {
+        let ks = ks_from_str("fffffff812345678 t static_func\n");
+        assert!(ks.contains_text_symbol("static_func"));
+        assert_eq!(
+            ks.get_text_symbol_addr("static_func"),
+            Some(0xfffffff812345678)
+        );
+    }
+
+    #[test]
+    fn data_symbol_found() {
+        let ks = ks_from_str("ffffffff81234000 D memstart_addr\n");
+        assert_eq!(
+            ks.get_data_symbol_addr("memstart_addr"),
+            Some(0xffffffff81234000)
+        );
+    }
+
+    #[test]
+    fn local_data_symbol_found() {
+        let ks = ks_from_str("ffffffff81234000 d some_local_var\n");
+        assert_eq!(
+            ks.get_data_symbol_addr("some_local_var"),
+            Some(0xffffffff81234000)
+        );
+    }
+
+    #[test]
+    fn symbol_not_found() {
+        let ks = ks_from_str("fffffff812345678 T my_func\n");
+        assert!(!ks.contains_text_symbol("other_func"));
+        assert_eq!(ks.get_text_symbol_addr("other_func"), None);
+        assert_eq!(ks.get_data_symbol_addr("my_func"), None);
+    }
+
+    #[test]
+    fn multiple_addresses_same_name() {
+        let input = "ffffffff81000000 T dup_sym\nffffffff82000000 T dup_sym\n";
+        let ks = ks_from_str(input);
+        // get_text_symbol_addr returns the first one
+        assert_eq!(ks.get_text_symbol_addr("dup_sym"), Some(0xffffffff81000000));
+    }
+
+    #[test]
+    fn mixed_symbol_types() {
+        let input = concat!(
+            "ffffffff81000000 T text_sym\n",
+            "ffffffff82000000 D data_sym\n",
+        );
+        let ks = ks_from_str(input);
+        assert!(ks.contains_text_symbol("text_sym"));
+        assert!(!ks.contains_text_symbol("data_sym"));
+        assert_eq!(
+            ks.get_data_symbol_addr("data_sym"),
+            Some(0xffffffff82000000)
+        );
+        assert_eq!(ks.get_data_symbol_addr("text_sym"), None);
+    }
+
+    #[test]
+    fn empty_input() {
+        let ks = ks_from_str("");
+        assert!(!ks.contains_text_symbol("anything"));
+        assert_eq!(ks.get_text_symbol_addr("anything"), None);
+    }
+
+    #[test]
+    fn parse_invalid_address() {
+        let result = KernelSymbols::from_reader("zzzzzz T bad_addr\n".as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_empty_symbol_name() {
+        let result = KernelSymbols::from_reader("ffffffff81000000 T\n".as_bytes());
+        assert!(result.is_err());
+    }
+}

--- a/kunai/src/lib.rs
+++ b/kunai/src/lib.rs
@@ -1,16 +1,13 @@
 #![deny(unused_imports)]
 
-use std::collections::HashSet;
-
-use aya::{
-    include_bytes_aligned, programs::ProgramError, util::kernel_symbols, Btf, Ebpf, EbpfLoader,
-    VerifierLogLevel,
-};
+use aya::{include_bytes_aligned, programs::ProgramError, Btf, Ebpf, EbpfLoader, VerifierLogLevel};
 use compat::Programs;
 use config::Config;
 use kunai_common::{config::BpfConfig, kernel, version::KernelVersion};
 use log::{debug, error, info, warn};
 use util::{page_shift, page_size};
+
+use crate::kallsyms::KernelSymbols;
 
 pub mod cache;
 pub mod compat;
@@ -19,6 +16,7 @@ pub mod containers;
 pub mod events;
 pub mod info;
 pub mod ioc;
+pub mod kallsyms;
 pub mod util;
 pub mod yara;
 
@@ -34,13 +32,12 @@ const BPF_ELF: &[u8] = {
 ///
 /// If a given probe name is not found
 #[allow(unused_variables)]
-fn configure_probes(conf: &Config, programs: &mut Programs, target: KernelVersion) {
-    // we need to be able to parse available symbols to check if some function exist
-    let sym = kernel_symbols()
-        .unwrap_or_default()
-        .into_values()
-        .collect::<HashSet<String>>();
-
+fn configure_probes(
+    conf: &Config,
+    symbols: &KernelSymbols,
+    programs: &mut Programs,
+    target: KernelVersion,
+) {
     // LSM probes are available only since 5.7
     // We disable them if we're not running in harden mode
     programs
@@ -98,7 +95,7 @@ fn configure_probes(conf: &Config, programs: &mut Programs, target: KernelVersio
 
     // syscore_resume may be missing if kernel is compiled without CONFIG_PM_SLEEP
     // see: https://github.com/kunai-project/kunai/issues/105
-    if !sym.contains("syscore_resume") {
+    if !symbols.contains_text_symbol("syscore_resume") {
         programs.expect_mut("enter_syscore_resume").disable();
         // the risk is we disable a probe that changed name (not desired)
         // we know that until v6.12 the function is there so print warning
@@ -115,20 +112,53 @@ fn configure_probes(conf: &Config, programs: &mut Programs, target: KernelVersio
 /// This function is responsible from loading eBPF code from a buffer
 /// into the appropriate Aya structure. It does not load the eBPF code
 /// into the kernel.
+#[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
 pub fn prepare_bpf(
     kernel: KernelVersion,
+    symbols: &KernelSymbols,
     conf: &Config,
     vll: VerifierLogLevel,
 ) -> anyhow::Result<Ebpf> {
     let page_size = page_size()? as u64;
     let page_shift = page_shift()?;
 
-    let mut bpf = EbpfLoader::new()
+    let mut loader = EbpfLoader::new();
+    loader
         .verifier_log_level(vll)
         .set_global("PAGE_SHIFT", &page_shift, true)
         .set_global("PAGE_SIZE", &page_size, true)
-        .set_global("LINUX_KERNEL_VERSION", &kernel, true)
-        .load(BPF_ELF)?;
+        .set_global("LINUX_KERNEL_VERSION", &kernel, true);
+
+    let mut bpf = cfg_select! {
+       target_arch = "x86_64" => {{
+          let vmemmap_base = symbols.get_data_symbol_addr("vmemmap_base").unwrap_or_else(|| {
+             warn!("could not read vmemmap_base from kallsyms");
+             0
+          });
+
+          let page_offset_base = symbols.get_data_symbol_addr("page_offset_base")
+              .unwrap_or_else(|| {
+                 warn!("could not read page_offset_base from kallsyms");
+                 0
+              });
+
+         debug!(
+            "page VA globals (x86_64): vmemmap_base={vmemmap_base:#x} \
+               page_offset_base={page_offset_base:#x}"
+         );
+
+         // these values are needed to access `page struct` data
+          loader
+              .set_global("VMEMMAP_BASE_PTR", &vmemmap_base, true)
+              .set_global("PAGE_OFFSET_BASE_PTR", &page_offset_base, true);
+
+          loader.load(BPF_ELF)?
+       }}
+
+       _ => {
+          loader.load(BPF_ELF)?
+       }
+    };
 
     BpfConfig::init_config_in_bpf(&mut bpf, conf.clone().try_into()?)
         .expect("failed to initialize bpf configuration");
@@ -141,6 +171,7 @@ pub fn prepare_bpf(
 /// program loader.
 pub fn load_and_attach_bpf<'a>(
     conf: &'a Config,
+    symbols: &KernelSymbols,
     kernel: KernelVersion,
     bpf: &'a mut Ebpf,
 ) -> anyhow::Result<()> {
@@ -156,7 +187,7 @@ pub fn load_and_attach_bpf<'a>(
     let mut programs = Programs::with_bpf(bpf).with_elf_info(BPF_ELF)?;
     let btf = Btf::from_sys_fs()?;
 
-    configure_probes(conf, &mut programs, kernel);
+    configure_probes(conf, symbols, &mut programs, kernel);
 
     // generic program loader
     for (_, p) in programs.sorted_by_prio() {

--- a/kunai/src/tests/kernel.rs
+++ b/kunai/src/tests/kernel.rs
@@ -4,6 +4,7 @@ use aya::VerifierLogLevel;
 use env_logger::Builder;
 use kunai::{
     config::Config,
+    kallsyms::KernelSymbols,
     util::{is_bpf_lsm_enabled, uname::Utsname},
 };
 use kunai_common::kernel;
@@ -69,6 +70,8 @@ fn integration() -> anyhow::Result<()> {
         }
     }
 
+    let kernel_syms = KernelSymbols::from_sys().unwrap_or_default();
+
     // we have lsm loading failure under aarch64 for kernel < 6.4.x
     // https://blog.exein.io/exploring-bpf-lsm-support-on-aarch64-with-ftrace/
     if cfg!(target_arch = "aarch64") && current_kernel < kernel!(6, 4, 0) {
@@ -76,8 +79,8 @@ fn integration() -> anyhow::Result<()> {
     }
 
     info!("loading ebpf bytes");
-    let mut bpf = kunai::prepare_bpf(current_kernel, &conf, verifier_level)?;
-    kunai::load_and_attach_bpf(&conf, current_kernel, &mut bpf)?;
+    let mut bpf = kunai::prepare_bpf(current_kernel, &kernel_syms, &conf, verifier_level)?;
+    kunai::load_and_attach_bpf(&conf, &kernel_syms, current_kernel, &mut bpf)?;
 
     Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.93"
+channel = "1.96"
 # supported cross-compilation targets
 # NB: one can compile to x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu but
 # those do not produce statically linked binaries.


### PR DESCRIPTION
## Summary

Fixes incorrect data captured from `bio_vec`-backed `iov_iter` (issue #267).
The root cause was a copy-paste error (`bv_len()` called instead of `bv_offset()`),
but the full fix required reworking `struct page → virtual address` translation to
be architecture-aware and resolving several BPF verifier rejections that surfaced after the fix.

## Motivation

`bio_vec` iteration was computing the source address using `bv_len` as the page
offset instead of `bv_offset`, producing corrupt or garbage data. Fixing that
exposed that `page_to_virt` assumed a fixed memory layout, which does not hold
across architectures or with KASLR on x86_64. Additionally, the BPF verifier
rejected the corrected code paths due to lost bounds information, requiring a
dedicated clamping helper.

## Changes

- **Fix `bio_vec` parsing**: `bv_offset()` was erroneously read via `bv_len()`; corrected field accessor
- **Architecture-aware `page_to_virt`**: `struct page → virt` translation now dispatched per target
  - x86_64: reads `vmemmap_base` and `page_offset_base` from kernel variables via `bpf_probe_read_kernel` (KASLR-safe); addresses passed from userspace via `/proc/kallsyms`
  - aarch64: infers layout by probing known `(VMEMMAP_START, PAGE_OFFSET)` candidates with `bpf_probe_read_kernel`
  - returns `Option<*const c_void>` instead of a potentially null raw pointer
- **`shim_size_of_page`**: C shim exposing `sizeof(struct page)` for CO-RE use
- **`verifier_clamp` BPF utility**: helper to clamp values in a way the BPF verifier can track
- **`KernelSymbols`**: userspace parser for `/proc/kallsyms` used to locate `vmemmap_base` and `page_offset_base` addresses at startup
- **Remove `count` parameter** from `fill_from_iov_iter` / `append_iov` / `append_bio_vec`: simplifies callers, buffer bounds are enforced internally
- **Toolchain bump to 1.95**: required for the `cfg_select!` macro used in arch dispatch
- **Fix config program loader**: corrected loader logic in the userspace binary

## Breaking Changes

- `Buffer::fill_from_iov_iter` signature changed: `count: Option<usize>` parameter removed
- Refactor `page::to_va()` to `page::page_to_virt` which now returns `Option<*const c_void>` instead of `*const c_void`

## Testing

- Existing kernel integration tests (`kunai/src/tests/kernel.rs`)
- BPF verifier acceptance (program loads without rejection on x86_64 and aarch64)
- Manual validation that `bio_vec`-backed writes produce correct data post-fix

## Notes

The `KernelSymbols` reader temporarily sets `kptr_restrict=1` to read non-zero
addresses when running as root, then restores the original value.
`aarch64` layout detection is heuristic: it tries a fixed set of known
`(VMEMMAP_START, PAGE_OFFSET)` pairs and picks the first whose derived virtual
address is readable via `bpf_probe_read_kernel`.
